### PR TITLE
Build on Mnemosyne; add test and site CI, and README badges

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,16 +11,20 @@ on:
 
 jobs:
   build:
-    name: JDK 21 Build
+    name: JDK 21 Build and Test
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check out OODT
+      # DRAT depends on Mnemosyne, the continuation of Apache OODT after the
+      # ASF retired it to the Attic. Built from source until
+      # ai.mattmann.mnemosyne:1.11.0 is published to Maven Central, at which
+      # point this checkout and install step can be dropped.
+      - name: Check out Mnemosyne
         uses: actions/checkout@v4
         with:
-          repository: chrismattmann/oodt
+          repository: chrismattmann/mnemosyne
           ref: master
-          path: oodt
+          path: mnemosyne
 
       - name: Check out DRAT
         uses: actions/checkout@v4
@@ -41,13 +45,36 @@ jobs:
           cache: npm
           cache-dependency-path: drat/webapps/proteus-new/src/main/webapp/resources/package-lock.json
 
-      - name: Install modernized OODT snapshot
-        working-directory: oodt
-        run: mvn -B -DskipTests clean install
+      - name: Install Mnemosyne 1.11.0
+        working-directory: mnemosyne
+        run: mvn -B -DskipTests -Dmaven.javadoc.skip=true clean install
 
-      - name: Build DRAT
+      # Tests run as part of install rather than a separate `mvn test`: the
+      # distribution module unpacks Tomcat at process-sources and needs the
+      # war artifacts, which the test phase alone does not produce.
+      - name: Build and test DRAT
         working-directory: drat
-        run: mvn -B -DskipTests clean install
+        run: mvn -B clean install
+
+      - name: Check the distribution contents
+        working-directory: drat
+        run: |
+          set -e
+          TARBALL=$(ls distribution/target/dms-distribution-*-bin.tar.gz)
+
+          # Java 9 removed the extension mechanism; any launcher still naming
+          # it fails at startup. Assert the scan is non-vacuous first so a
+          # wildcard matching nothing cannot pass silently.
+          LAUNCHERS=$(tar tzf "$TARBALL" | grep -cE '^[^/]+/bin/[^/]+$')
+          echo "scanning $LAUNCHERS launcher scripts"
+          test "$LAUNCHERS" -gt 10
+          ! tar xzOf "$TARBALL" --wildcards '*/bin/*' 2>/dev/null | grep -q 'java.ext.dirs'
+
+          # Tomcat ships bin/*.sh non-executable through the fileSet unless
+          # they are re-added with an explicit mode.
+          tar tvzf "$TARBALL" | grep -E 'tomcat/bin/catalina.sh' | grep -q '^-rwx'
+
+          echo "distribution contents OK"
 
       - name: Upload DRAT distribution
         uses: actions/upload-artifact@v4

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -1,0 +1,102 @@
+name: Site
+
+on:
+  push:
+    branches:
+      - master
+    # The landing page is hand-maintained on the asf-site branch. Only
+    # regenerate when something that feeds the published API docs changes.
+    paths:
+      - '**/src/main/java/**'
+      - '**/pom.xml'
+      - '.github/workflows/site.yml'
+  workflow_dispatch:
+
+# Pushing the regenerated docs back to the site branch.
+permissions:
+  contents: write
+
+concurrency:
+  group: site
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    name: Publish API docs
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out Mnemosyne
+        uses: actions/checkout@v4
+        with:
+          repository: chrismattmann/mnemosyne
+          ref: master
+          path: mnemosyne
+
+      - name: Check out DRAT
+        uses: actions/checkout@v4
+        with:
+          path: drat
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Install Mnemosyne 1.11.0
+        working-directory: mnemosyne
+        run: mvn -B -DskipTests -Dmaven.javadoc.skip=true clean install
+
+      # distribution is excluded: it unpacks Tomcat at process-sources and
+      # needs war artifacts that a javadoc-only invocation never builds.
+      # failOnError is off because this is a long-lived codebase whose javadoc
+      # predates the stricter JDK 21 doclint; a malformed comment should not
+      # stop the site from publishing.
+      - name: Generate aggregate javadoc
+        working-directory: drat
+        run: |
+          mvn -B javadoc:aggregate \
+            -DskipTests \
+            -Dmaven.javadoc.failOnError=false \
+            -pl '!distribution'
+
+      - name: Verify the docs were actually produced
+        working-directory: drat
+        run: |
+          set -e
+          test -f target/reports/apidocs/index.html
+          COUNT=$(find target/reports/apidocs -type f | wc -l)
+          echo "generated $COUNT files"
+          # Guard against publishing an empty directory over a working site.
+          test "$COUNT" -gt 50
+
+      - name: Check out the site branch
+        uses: actions/checkout@v4
+        with:
+          ref: asf-site
+          path: site
+
+      - name: Stage the docs into the site
+        run: |
+          set -e
+          rm -rf site/apidocs
+          mkdir -p site/apidocs
+          cp -R drat/target/reports/apidocs/. site/apidocs/
+          # .nojekyll keeps GitHub Pages from stripping javadoc's underscore
+          # directories, which would break the generated navigation.
+          touch site/.nojekyll
+
+      - name: Commit and push if anything changed
+        working-directory: site
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "API docs unchanged; nothing to publish."
+            exit 0
+          fi
+          git commit -m "Publish API docs from ${GITHUB_SHA::8}"
+          git push origin asf-site

--- a/README.md
+++ b/README.md
@@ -1,7 +1,14 @@
 Distributed Release Audit Tool (DRAT)
 ====
+
+[![Build](https://github.com/chrismattmann/drat/actions/workflows/build.yml/badge.svg?branch=master)](https://github.com/chrismattmann/drat/actions/workflows/build.yml)
+[![Site](https://github.com/chrismattmann/drat/actions/workflows/site.yml/badge.svg?branch=master)](https://github.com/chrismattmann/drat/actions/workflows/site.yml)
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
+[![JDK](https://img.shields.io/badge/JDK-21-orange.svg)](https://adoptium.net/)
+[![Powered by Mnemosyne](https://img.shields.io/badge/powered%20by-Mnemosyne%201.11.0-6E4B8E.svg)](https://github.com/chrismattmann/mnemosyne)
+[![Website](https://img.shields.io/badge/website-chrismattmann.github.io%2Fdrat-informational.svg)](https://chrismattmann.github.io/drat/)
  
-A distributed, parallelized (Map Reduce) wrapper around [Apache RAT&trade;](http://creadur.apache.org/rat/) (Release Audit Tool). RAT is used to check for proper licensing in software projects. However, RAT takes a prohibitively long time to analyze large repositories of code, since it can only run on one JVM. Furthermore, RAT isn't customizable by file type or file size and provides no incremental output. This wrapper dramatically speeds up the process by leveraging Apache OODT&trade; to parallelize and workflow the following components:
+A distributed, parallelized (Map Reduce) wrapper around [Apache RAT&trade;](http://creadur.apache.org/rat/) (Release Audit Tool). RAT is used to check for proper licensing in software projects. However, RAT takes a prohibitively long time to analyze large repositories of code, since it can only run on one JVM. Furthermore, RAT isn't customizable by file type or file size and provides no incremental output. This wrapper dramatically speeds up the process by leveraging [Mnemosyne](https://github.com/chrismattmann/mnemosyne) — the continuation of Apache OODT&trade;, which the ASF retired to the Attic in 2023 — to parallelize and workflow the following components:
 
 1. Apache Solr&trade; based exploration of a CM repository (e.g., Git, SVN, etc.) and classification of that repository based on MIME type using Apache Tika&trade;.
 2. A MIME partitioner that uses Apache Tika&trade; to automatically deduce and classify by file type and then partition Apache RAT&trade; jobs based on sets of 100 files per type (configurable) -- the M/R "partitioner"
@@ -23,6 +30,3 @@ You can clone the wiki by running
 
 Visit our new website [chrismattmann.github.io/drat](https://chrismattmann.github.io/drat/) at [Github](https://github.com/).
 
----
-
-Current build status: [![Build](https://github.com/chrismattmann/drat/actions/workflows/build.yml/badge.svg?branch=master)](https://github.com/chrismattmann/drat/actions/workflows/build.yml)

--- a/crawler/pom.xml
+++ b/crawler/pom.xml
@@ -43,13 +43,13 @@
       <scope>runtime</scope>
       <exclusions>
         <exclusion>
-          <groupId>org.apache.oodt</groupId>
+          <groupId>ai.mattmann.mnemosyne</groupId>
           <artifactId>cas-filemgr</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.apache.oodt</groupId>
+      <groupId>ai.mattmann.mnemosyne</groupId>
       <artifactId>cas-crawler</artifactId>
       <version>${oodt.version}</version>
     </dependency>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -38,35 +38,35 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.oodt</groupId>
+      <groupId>ai.mattmann.mnemosyne</groupId>
       <artifactId>cas-metadata</artifactId>
       <version>${oodt.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.oodt</groupId>
+      <groupId>ai.mattmann.mnemosyne</groupId>
       <artifactId>cas-filemgr</artifactId>
       <version>${oodt.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.oodt</groupId>
+      <groupId>ai.mattmann.mnemosyne</groupId>
       <artifactId>pcs-core</artifactId>
       <version>${oodt.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.oodt</groupId>
+      <groupId>ai.mattmann.mnemosyne</groupId>
       <artifactId>cas-pge</artifactId>
       <version>${oodt.version}</version>
       <exclusions>
         <exclusion> 
-          <groupId>org.apache.oodt</groupId>
+          <groupId>ai.mattmann.mnemosyne</groupId>
           <artifactId>cas-filemgr</artifactId>
         </exclusion>
         <exclusion> 
-          <groupId>org.apache.oodt</groupId>
+          <groupId>ai.mattmann.mnemosyne</groupId>
           <artifactId>cas-workflow</artifactId>
         </exclusion>        
         <exclusion> 
-          <groupId>org.apache.oodt</groupId>
+          <groupId>ai.mattmann.mnemosyne</groupId>
           <artifactId>cas-crawler</artifactId>
         </exclusion>                
       </exclusions>       

--- a/filemgr/pom.xml
+++ b/filemgr/pom.xml
@@ -44,13 +44,13 @@
       <scope>runtime</scope>
       <exclusions>
         <exclusion>
-          <groupId>org.apache.oodt</groupId>
+          <groupId>ai.mattmann.mnemosyne</groupId>
           <artifactId>cas-filemgr</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.apache.oodt</groupId>
+      <groupId>ai.mattmann.mnemosyne</groupId>
       <artifactId>cas-filemgr</artifactId>
       <version>${oodt.version}</version>
     </dependency>

--- a/pcs/pom.xml
+++ b/pcs/pom.xml
@@ -44,13 +44,13 @@
       <scope>runtime</scope>
       <exclusions>
         <exclusion>
-          <groupId>org.apache.oodt</groupId>
+          <groupId>ai.mattmann.mnemosyne</groupId>
           <artifactId>cas-filemgr</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.apache.oodt</groupId>
+      <groupId>ai.mattmann.mnemosyne</groupId>
       <artifactId>pcs-core</artifactId>
       <version>${oodt.version}</version>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1,24 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <parent>
-    <groupId>org.apache</groupId>
-    <artifactId>apache</artifactId>
-    <version>21</version>
-    <relativePath />
-  </parent>
+  <!--
+    apache/drat was retired to the Apache Attic and its repository is archived.
+    This project continues at chrismattmann/drat, so the org.apache:apache
+    parent, which configures ASF release staging and Nexus, is not inherited.
+  -->
 
   <groupId>org.apache.drat</groupId>
   <artifactId>dms</artifactId>
-  <name>Apache DRAT</name>
+  <name>DRAT</name>
   <packaging>pom</packaging>
-  <description>The Apache Distributed Release Auditing Tool (DRAT).</description>
+  <description>DRAT, the Distributed Release Auditing Tool.</description>
   <version>1.1-SNAPSHOT</version>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <oodt.version>1.10-SNAPSHOT</oodt.version>
+    <oodt.version>1.11.0</oodt.version>
     <junit.version>4.12</junit.version>
     <maven.compiler.plugin.version>3.13.0</maven.compiler.plugin.version>
     <maven.javadoc.plugin.version>3.11.2</maven.javadoc.plugin.version>
@@ -122,10 +121,15 @@
 
 
   <scm>
-    <connection>scm:git:git@github.com:apache/drat.git</connection>
-    <developerConnection>scm:git:git@github.com:apache/drat.git</developerConnection>
-    <url>http://github.com/apache/drat</url>
+    <connection>scm:git:https://github.com/chrismattmann/drat.git</connection>
+    <developerConnection>scm:git:https://github.com/chrismattmann/drat.git</developerConnection>
+    <url>https://github.com/chrismattmann/drat</url>
     <tag>HEAD</tag>
   </scm>
+
+  <issueManagement>
+    <system>GitHub</system>
+    <url>https://github.com/chrismattmann/drat/issues</url>
+  </issueManagement>
 
 </project>

--- a/proteus/pom.xml
+++ b/proteus/pom.xml
@@ -103,22 +103,22 @@
 		   <scope>runtime</scope>
 		</dependency>        
         <dependency>
-            <groupId>org.apache.oodt</groupId>
+            <groupId>ai.mattmann.mnemosyne</groupId>
             <artifactId>cas-metadata</artifactId>
             <version>${oodt.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.oodt</groupId>
+            <groupId>ai.mattmann.mnemosyne</groupId>
             <artifactId>cas-filemgr</artifactId>
             <version>${oodt.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.oodt</groupId>
+            <groupId>ai.mattmann.mnemosyne</groupId>
             <artifactId>cas-workflow</artifactId>
             <version>${oodt.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.oodt</groupId>
+            <groupId>ai.mattmann.mnemosyne</groupId>
             <artifactId>pcs-core</artifactId>
             <version>${oodt.version}</version>
         </dependency>

--- a/resmgr/pom.xml
+++ b/resmgr/pom.xml
@@ -44,13 +44,13 @@
       <scope>runtime</scope>
       <exclusions>
         <exclusion>
-          <groupId>org.apache.oodt</groupId>
+          <groupId>ai.mattmann.mnemosyne</groupId>
           <artifactId>cas-filemgr</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.apache.oodt</groupId>
+      <groupId>ai.mattmann.mnemosyne</groupId>
       <artifactId>cas-resource</artifactId>
       <version>${oodt.version}</version>
     </dependency>

--- a/webapps/fmprod/pom.xml
+++ b/webapps/fmprod/pom.xml
@@ -41,7 +41,7 @@
           <failOnMissingWebXml>false</failOnMissingWebXml>
           <overlays>
             <overlay>
-              <groupId>org.apache.oodt</groupId>
+              <groupId>ai.mattmann.mnemosyne</groupId>
               <artifactId>cas-product</artifactId>
             </overlay>
           </overlays>
@@ -52,7 +52,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.oodt</groupId>
+      <groupId>ai.mattmann.mnemosyne</groupId>
       <artifactId>cas-product</artifactId>
       <version>${oodt.version}</version>
       <type>war</type>

--- a/webapps/opsui/pom.xml
+++ b/webapps/opsui/pom.xml
@@ -40,7 +40,7 @@
         <configuration>
           <overlays>
             <overlay>
-              <groupId>org.apache.oodt</groupId>
+              <groupId>ai.mattmann.mnemosyne</groupId>
               <artifactId>pcs-opsui</artifactId>
               <excludes>
                 <exclude>WEB-INF/web.xml</exclude>
@@ -55,7 +55,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.oodt</groupId>
+      <groupId>ai.mattmann.mnemosyne</groupId>
       <artifactId>pcs-opsui</artifactId>
       <version>${oodt.version}</version>
       <type>war</type>

--- a/webapps/pcs-services/pom.xml
+++ b/webapps/pcs-services/pom.xml
@@ -41,7 +41,7 @@
           <failOnMissingWebXml>false</failOnMissingWebXml>
           <overlays>
             <overlay>
-              <groupId>org.apache.oodt</groupId>
+              <groupId>ai.mattmann.mnemosyne</groupId>
               <artifactId>pcs-services</artifactId>
             </overlay>
           </overlays>
@@ -52,7 +52,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.oodt</groupId>
+      <groupId>ai.mattmann.mnemosyne</groupId>
       <artifactId>pcs-services</artifactId>
       <version>${oodt.version}</version>
       <type>war</type>

--- a/workflow/pom.xml
+++ b/workflow/pom.xml
@@ -43,36 +43,36 @@
       <scope>runtime</scope>
       <exclusions>
         <exclusion>
-          <groupId>org.apache.oodt</groupId>
+          <groupId>ai.mattmann.mnemosyne</groupId>
           <artifactId>cas-filemgr</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.apache.oodt</groupId>
+      <groupId>ai.mattmann.mnemosyne</groupId>
       <artifactId>cas-filemgr</artifactId>
       <version>${oodt.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.oodt</groupId>
+      <groupId>ai.mattmann.mnemosyne</groupId>
       <artifactId>cas-workflow</artifactId>
       <version>${oodt.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.oodt</groupId>
+      <groupId>ai.mattmann.mnemosyne</groupId>
       <artifactId>cas-pge</artifactId>
       <version>${oodt.version}</version>
       <exclusions>
         <exclusion> 
-          <groupId>org.apache.oodt</groupId>
+          <groupId>ai.mattmann.mnemosyne</groupId>
           <artifactId>cas-filemgr</artifactId>
         </exclusion>
         <exclusion> 
-          <groupId>org.apache.oodt</groupId>
+          <groupId>ai.mattmann.mnemosyne</groupId>
           <artifactId>cas-workflow</artifactId>
         </exclusion>        
         <exclusion> 
-          <groupId>org.apache.oodt</groupId>
+          <groupId>ai.mattmann.mnemosyne</groupId>
           <artifactId>cas-crawler</artifactId>
         </exclusion>                
       </exclusions>      


### PR DESCRIPTION
## The CI was silently building the wrong OODT

`build.yml` checked out `chrismattmann/oodt`. That repository was renamed, and
the old name now redirects to an **archived fork holding the pre-rename tree** —
so CI was compiling DRAT against OODT without the JDK 21 and Avro work, and
passing. It now checks out
[`chrismattmann/mnemosyne`](https://github.com/chrismattmann/mnemosyne).

## Coordinates

Apache OODT was retired to the Attic in April 2023; Mnemosyne is its
continuation.

```diff
-<groupId>org.apache.oodt</groupId>
+<groupId>ai.mattmann.mnemosyne</groupId>
-<oodt.version>1.10-SNAPSHOT</oodt.version>
+<oodt.version>1.11.0</oodt.version>
```

38 sites across 14 poms. Detached from the `org.apache:apache:21` parent —
unlike Mnemosyne, DRAT already pinned every plugin version, so nothing needed
backfilling. SCM repointed at `chrismattmann/drat`, since `apache/drat` is
archived and read-only. Apache branding dropped from the project name and
description.

## CI now actually tests

Tests run inside `mvn install` rather than a standalone `mvn test`: the
distribution module unpacks Tomcat at `process-sources` and needs war artifacts
the test phase alone never produces. **12 tests pass.**

The build job also asserts against the packaged distribution — no launcher
references `java.ext.dirs`, Tomcat's scripts keep their executable bit, and the
launcher scan is checked to be non-vacuous first so a wildcard matching nothing
cannot pass silently.

## Site publishing

New `site.yml` regenerates aggregate javadoc and publishes it to
`asf-site/apidocs`, which GitHub Pages already serves at
[chrismattmann.github.io/drat](https://chrismattmann.github.io/drat/). The
landing page stays hand-maintained; only the generated API docs refresh.

Safeguards, because this pushes to a live site:

- runs only when Java sources or poms change
- verifies `index.html` exists and the file count clears a floor **before**
  publishing, so an empty build cannot overwrite a working site
- skips the commit entirely when nothing changed
- `concurrency` group prevents overlapping pushes to the branch
- `.nojekyll` so Pages does not strip javadoc's underscore directories

`distribution` is excluded for the same reason as the tests, and doclint
failures do not block: the javadoc predates JDK 21's stricter rules, and a
malformed comment should not take the site down.

## Badges

Moved to the top and expanded — build, site, license (Apache 2.0), JDK 21,
Powered by Mnemosyne, and the website. The old build-status line buried at line
28 is removed. The engine reference in the description now points at Mnemosyne
with the heritage noted.

## Deliberately not changed

DRAT's **own** groupId is still `org.apache.drat`. That is an artifact identity
decision rather than a dependency one, and publishing under an Apache namespace
is not possible regardless — it deserves its own call rather than being folded
in here.

Verified locally: builds clean on OpenJDK 21 against `cas-*-1.11.0`, 12 tests
pass, aggregate javadoc produces 164 files, and every distribution assertion in
the workflow was run by hand first.