### PR TITLE
Publish DRAT as ai.mattmann.drat, and make mvn test work

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,9 +49,8 @@ jobs:
         working-directory: mnemosyne
         run: mvn -B -DskipTests -Dmaven.javadoc.skip=true clean install
 
-      # Tests run as part of install rather than a separate `mvn test`: the
-      # distribution module unpacks Tomcat at process-sources and needs the
-      # war artifacts, which the test phase alone does not produce.
+      # install rather than test, so the packaged distribution exists for the
+      # assertions below. `mvn test` on its own also works.
       - name: Build and test DRAT
         working-directory: drat
         run: mvn -B clean install

--- a/crawler/pom.xml
+++ b/crawler/pom.xml
@@ -3,7 +3,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.drat</groupId>
+    <groupId>ai.mattmann.drat</groupId>
     <artifactId>dms</artifactId>
     <version>1.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
@@ -36,7 +36,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.drat</groupId>
+      <groupId>ai.mattmann.drat</groupId>
       <artifactId>dms-extensions</artifactId>
       <version>${project.parent.version}</version>
       <type>jar</type>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -3,7 +3,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.drat</groupId>
+    <groupId>ai.mattmann.drat</groupId>
     <artifactId>dms</artifactId>
     <version>1.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath> 
@@ -18,106 +18,106 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.drat</groupId>
+      <groupId>ai.mattmann.drat</groupId>
       <artifactId>dms-rat</artifactId>
       <version>${project.parent.version}</version>
       <type>tar.gz</type>
       <classifier>bin</classifier>
     </dependency>
     <dependency>
-      <groupId>org.apache.drat</groupId>
+      <groupId>ai.mattmann.drat</groupId>
       <artifactId>dms-filemgr</artifactId>
       <version>${project.parent.version}</version>
       <type>tar.gz</type>
       <classifier>bin</classifier>
     </dependency>
     <dependency>
-      <groupId>org.apache.drat</groupId>
+      <groupId>ai.mattmann.drat</groupId>
       <artifactId>dms-crawler</artifactId>
       <version>${project.parent.version}</version>
       <type>tar.gz</type>
       <classifier>bin</classifier>
     </dependency>
     <dependency>
-      <groupId>org.apache.drat</groupId>
+      <groupId>ai.mattmann.drat</groupId>
       <artifactId>dms-workflow</artifactId>
       <version>${project.parent.version}</version>
       <type>tar.gz</type>
       <classifier>bin</classifier>
     </dependency>
     <dependency>
-      <groupId>org.apache.drat</groupId>
+      <groupId>ai.mattmann.drat</groupId>
       <artifactId>dms-pge</artifactId>
       <version>${project.parent.version}</version>
       <type>tar.gz</type>
       <classifier>bin</classifier>
     </dependency>
     <dependency>
-      <groupId>org.apache.drat</groupId>
+      <groupId>ai.mattmann.drat</groupId>
       <artifactId>dms-solr</artifactId>
       <version>${project.parent.version}</version>
       <type>tar.gz</type>
       <classifier>bin</classifier>
     </dependency>    
     <dependency>
-      <groupId>org.apache.drat</groupId>
+      <groupId>ai.mattmann.drat</groupId>
       <artifactId>dms-pcs</artifactId>
       <version>${project.parent.version}</version>
       <type>tar.gz</type>
       <classifier>bin</classifier>
     </dependency>
     <dependency>
-      <groupId>org.apache.drat</groupId>
+      <groupId>ai.mattmann.drat</groupId>
       <artifactId>dms-resmgr</artifactId>
       <version>${project.parent.version}</version>
       <type>tar.gz</type>
       <classifier>bin</classifier>
     </dependency>
     <dependency>
-      <groupId>org.apache.drat</groupId>
+      <groupId>ai.mattmann.drat</groupId>
       <artifactId>dms-extensions</artifactId>
       <version>${project.parent.version}</version>
       <type>tar.gz</type>
       <classifier>bin</classifier>
     </dependency>
     <dependency>
-      <groupId>org.apache.drat</groupId>
+      <groupId>ai.mattmann.drat</groupId>
       <artifactId>dms-opsui</artifactId>
       <version>${project.parent.version}</version>
       <type>war</type>
     </dependency>
     <dependency>
-      <groupId>org.apache.drat</groupId>
+      <groupId>ai.mattmann.drat</groupId>
       <artifactId>dms-pcs-services</artifactId>
       <version>${project.parent.version}</version>
       <type>war</type>
     </dependency>
     <dependency>
-      <groupId>org.apache.drat</groupId>
+      <groupId>ai.mattmann.drat</groupId>
       <artifactId>dms-fmprod</artifactId>
       <version>${project.parent.version}</version>
       <type>war</type>
     </dependency>
     <dependency>
-      <groupId>org.apache.drat</groupId>
+      <groupId>ai.mattmann.drat</groupId>
       <artifactId>dms-solr-webapp</artifactId>
       <version>${project.parent.version}</version>
       <type>war</type>
     </dependency>
     <dependency>
-      <groupId>org.apache.drat</groupId>
+      <groupId>ai.mattmann.drat</groupId>
       <artifactId>dms-proteus</artifactId>
       <version>${project.parent.version}</version>
       <type>war</type>
     </dependency>
     <dependency>
-      <groupId>org.apache.drat</groupId>
+      <groupId>ai.mattmann.drat</groupId>
       <artifactId>dms-viz</artifactId>
       <version>${project.parent.version}</version>
       <type>war</type>
     </dependency>
     <dependency>
-      <groupId>org.apache.drat</groupId>
+      <groupId>ai.mattmann.drat</groupId>
       <artifactId>dms-proteus-new</artifactId>
       <version>${project.parent.version}</version>
       <type>war</type>
@@ -138,7 +138,16 @@
         <executions>
           <execution>
             <id>unpack-tomcat</id>
-            <phase>process-sources</phase>
+            <!--
+              prepare-package, not process-sources. This unpacks war artifacts
+              produced by sibling modules, which do not exist until those
+              modules reach package. Binding it early made `mvn test` fail:
+              the reactor builds siblings only through test, so the wars were
+              absent while this execution still ran. prepare-package runs
+              immediately before package, so the assembly still sees the
+              unpacked layout.
+            -->
+            <phase>prepare-package</phase>
             <goals>
               <goal>unpack</goal>
             </goals>
@@ -153,49 +162,49 @@
                   <outputDirectory>${project.build.directory}/</outputDirectory>
                 </artifactItem>
                 <artifactItem>
-                  <groupId>org.apache.drat</groupId>
+                  <groupId>ai.mattmann.drat</groupId>
                   <artifactId>${project.parent.artifactId}-opsui</artifactId>
                   <type>war</type>
                   <overWrite>false</overWrite>
                   <outputDirectory>${project.build.directory}/apache-tomcat-${tomcat.version}/webapps/opsui</outputDirectory>
                 </artifactItem>
                 <artifactItem>
-                  <groupId>org.apache.drat</groupId>
+                  <groupId>ai.mattmann.drat</groupId>
                   <artifactId>${project.parent.artifactId}-pcs-services</artifactId>
                   <type>war</type>
                   <overWrite>false</overWrite>
                   <outputDirectory>${project.build.directory}/apache-tomcat-${tomcat.version}/webapps/pcs</outputDirectory>
                 </artifactItem>
                 <artifactItem>
-                  <groupId>org.apache.drat</groupId>
+                  <groupId>ai.mattmann.drat</groupId>
                   <artifactId>${project.parent.artifactId}-fmprod</artifactId>
                   <type>war</type>
                   <overWrite>false</overWrite>
                   <outputDirectory>${project.build.directory}/apache-tomcat-${tomcat.version}/webapps/fmprod</outputDirectory>
                 </artifactItem>
                 <artifactItem>
-                  <groupId>org.apache.drat</groupId>
+                  <groupId>ai.mattmann.drat</groupId>
                   <artifactId>${project.parent.artifactId}-solr-webapp</artifactId>
                   <type>war</type>
                   <overWrite>true</overWrite>
                   <outputDirectory>${project.build.directory}/apache-tomcat-${tomcat.version}/webapps/solr</outputDirectory>
                 </artifactItem>                
                 <artifactItem>
-                  <groupId>org.apache.drat</groupId>
+                  <groupId>ai.mattmann.drat</groupId>
                   <artifactId>${project.parent.artifactId}-proteus</artifactId>
                   <type>war</type>
                   <overWrite>true</overWrite>
                   <outputDirectory>${project.build.directory}/apache-tomcat-${tomcat.version}/webapps/proteus</outputDirectory>
                 </artifactItem>
                 <artifactItem>
-                  <groupId>org.apache.drat</groupId>
+                  <groupId>ai.mattmann.drat</groupId>
                   <artifactId>${project.parent.artifactId}-viz</artifactId>
                   <type>war</type>
                   <overWrite>true</overWrite>
                   <outputDirectory>${project.build.directory}/apache-tomcat-${tomcat.version}/webapps/viz</outputDirectory>
                 </artifactItem>
 		<artifactItem>
-                  <groupId>org.apache.drat</groupId>
+                  <groupId>ai.mattmann.drat</groupId>
                   <artifactId>${project.parent.artifactId}-proteus-new</artifactId>
                   <type>war</type>
                   <overWrite>true</overWrite>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -3,7 +3,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.drat</groupId>
+    <groupId>ai.mattmann.drat</groupId>
     <artifactId>dms</artifactId>
     <version>1.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>

--- a/filemgr/pom.xml
+++ b/filemgr/pom.xml
@@ -3,7 +3,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.drat</groupId>
+    <groupId>ai.mattmann.drat</groupId>
     <artifactId>dms</artifactId>
     <version>1.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
@@ -37,7 +37,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.drat</groupId>
+      <groupId>ai.mattmann.drat</groupId>
       <artifactId>dms-extensions</artifactId>
       <version>${project.parent.version}</version>
       <type>jar</type>

--- a/pcs/pom.xml
+++ b/pcs/pom.xml
@@ -3,7 +3,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.drat</groupId>
+    <groupId>ai.mattmann.drat</groupId>
     <artifactId>dms</artifactId>
     <version>1.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
@@ -37,7 +37,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.drat</groupId>
+      <groupId>ai.mattmann.drat</groupId>
       <artifactId>dms-extensions</artifactId>
       <version>${project.parent.version}</version>
       <type>jar</type>

--- a/pge/pom.xml
+++ b/pge/pom.xml
@@ -3,7 +3,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.drat</groupId>
+    <groupId>ai.mattmann.drat</groupId>
     <artifactId>dms</artifactId>
     <version>1.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     parent, which configures ASF release staging and Nexus, is not inherited.
   -->
 
-  <groupId>org.apache.drat</groupId>
+  <groupId>ai.mattmann.drat</groupId>
   <artifactId>dms</artifactId>
   <name>DRAT</name>
   <packaging>pom</packaging>

--- a/proteus/pom.xml
+++ b/proteus/pom.xml
@@ -19,7 +19,7 @@
 
         <modelVersion>4.0.0</modelVersion>
         <parent>
-                <groupId>org.apache.drat</groupId>
+                <groupId>ai.mattmann.drat</groupId>
                 <artifactId>dms</artifactId>
                 <version>1.1-SNAPSHOT</version>
                 <relativePath>../pom.xml</relativePath>

--- a/rat/pom.xml
+++ b/rat/pom.xml
@@ -3,7 +3,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.drat</groupId>
+    <groupId>ai.mattmann.drat</groupId>
     <artifactId>dms</artifactId>
     <version>1.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>

--- a/resmgr/pom.xml
+++ b/resmgr/pom.xml
@@ -3,7 +3,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.drat</groupId>
+    <groupId>ai.mattmann.drat</groupId>
     <artifactId>dms</artifactId>
     <version>1.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
@@ -37,7 +37,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.drat</groupId>
+      <groupId>ai.mattmann.drat</groupId>
       <artifactId>dms-extensions</artifactId>
       <version>${project.parent.version}</version>
       <type>jar</type>

--- a/solr/pom.xml
+++ b/solr/pom.xml
@@ -3,7 +3,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.drat</groupId>
+    <groupId>ai.mattmann.drat</groupId>
     <artifactId>dms</artifactId>
     <version>1.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>

--- a/webapps/fmprod/pom.xml
+++ b/webapps/fmprod/pom.xml
@@ -3,7 +3,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.drat</groupId>
+    <groupId>ai.mattmann.drat</groupId>
     <artifactId>dms</artifactId>
     <version>1.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>

--- a/webapps/opsui/pom.xml
+++ b/webapps/opsui/pom.xml
@@ -3,7 +3,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.drat</groupId>
+    <groupId>ai.mattmann.drat</groupId>
     <artifactId>dms</artifactId>
     <version>1.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>

--- a/webapps/pcs-services/pom.xml
+++ b/webapps/pcs-services/pom.xml
@@ -3,7 +3,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.drat</groupId>
+    <groupId>ai.mattmann.drat</groupId>
     <artifactId>dms</artifactId>
     <version>1.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>

--- a/webapps/pom.xml
+++ b/webapps/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.drat</groupId>
+    <groupId>ai.mattmann.drat</groupId>
     <artifactId>dms</artifactId>
     <version>1.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>

--- a/webapps/proteus-new/pom.xml
+++ b/webapps/proteus-new/pom.xml
@@ -3,7 +3,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.drat</groupId>
+    <groupId>ai.mattmann.drat</groupId>
     <artifactId>dms</artifactId>
     <version>1.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>

--- a/webapps/solr-webapp/pom.xml
+++ b/webapps/solr-webapp/pom.xml
@@ -3,7 +3,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.drat</groupId>
+    <groupId>ai.mattmann.drat</groupId>
     <artifactId>dms</artifactId>
     <version>1.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>

--- a/webapps/viz/pom.xml
+++ b/webapps/viz/pom.xml
@@ -3,7 +3,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.drat</groupId>
+    <groupId>ai.mattmann.drat</groupId>
     <artifactId>dms</artifactId>
     <version>1.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>

--- a/workflow/pom.xml
+++ b/workflow/pom.xml
@@ -3,7 +3,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.drat</groupId>
+    <groupId>ai.mattmann.drat</groupId>
     <artifactId>dms</artifactId>
     <version>1.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
@@ -36,7 +36,7 @@
  
   <dependencies>
     <dependency>
-      <groupId>org.apache.drat</groupId>
+      <groupId>ai.mattmann.drat</groupId>
       <artifactId>dms-extensions</artifactId>
       <version>${project.parent.version}</version>
       <type>jar</type>


### PR DESCRIPTION
## Coordinates

DRAT's own groupId was still `org.apache.drat`. `apache/drat` is retired to the
Attic and archived; this project continues here under its original author and
steward. The Apache namespace also cannot be published to — Maven Central
requires ownership of the groupId, so `org.apache.drat` was a permanent dead end
for releases.

```diff
-<groupId>org.apache.drat</groupId>
+<groupId>ai.mattmann.drat</groupId>
```

52 sites across 24 poms. Coordinates only: DRAT has **no** Java packages under
`org.apache.drat`, and nothing outside the poms referenced it, so no source or
configuration changed. Verified before the sweep rather than assumed.

This completes the pair with [Mnemosyne](https://github.com/chrismattmann/mnemosyne)
(`ai.mattmann.mnemosyne`), which DRAT depends on.

## `mvn test` now works

It previously failed outright:

```
Failed to execute goal maven-dependency-plugin:unpack (unpack-tomcat)
The source file webapps/solr-webapp/target/classes doesn't exist
```

**Cause:** `unpack-tomcat` was bound to `process-sources` — very early — but it
unpacks *war artifacts produced by sibling modules*. Running `mvn test` builds
those siblings only through the `test` phase, so the wars did not exist yet
while this execution still ran.

**Fix:** bind it to `prepare-package`, which runs immediately before `package`.
The assembly still sees the unpacked layout, and the test phase never reaches
it.

| | before | after |
|---|---|---|
| `mvn clean test` | ❌ build failure | ✅ 12 tests, BUILD SUCCESS |
| `mvn clean install` | ✅ 12 tests | ✅ 12 tests, distribution intact |

Distribution verified unchanged after the phase move: Tomcat unpacked (2,769
files), all seven webapps present (`fmprod`, `opsui`, `pcs`, `proteus`,
`proteus-new`, `solr`, `viz`), seven Mnemosyne 1.11.0 jars.

The build workflow keeps using `install`, so the packaged distribution exists
for its artifact assertions — but the comment claiming `test` *could not* work
is now corrected.

## Note

`chrismattmann/bigtranslate` carries the identical `unpack-tomcat` binding at
`process-sources`, so `mvn test` fails there for the same reason. Same one-line
fix, tracked separately.