### PR TITLE
Replace USC/IRDS footer links with Mattmann AI

### DIFF
--- a/index.html
+++ b/index.html
@@ -181,9 +181,7 @@
                         <ul style="list-style-type: none;">
                          
                             <li><a href="http://github.com/chrismattmann/" target="_blank"><h4 class="white-text">Chris Mattmann's GitHub</h4></a>
-                            <li><a class="white-text" href="https://github.com/USCDataScience/" target="_blank">USC Data Science</a>
-                            </li>
-                            <li><a class="white-text" href="http://irds.usc.edu/" target="_blank">IRDS Website</a></li>
+                            <li><a class="white-text" href="http://mattmann.ai" target="_blank">Mattmann AI</a></li>
                             <li><a class="white-text" href="https://github.com/sponsors/chrismattmann" target="_blank">Become
                                 a Sponsor</a></li>
                             <li><a class="white-text" href="https://github.com/chrismattmann/drat/issues/" target="_blank">Report a Bug</a></li>


### PR DESCRIPTION
Removes the USC Data Science and IRDS footer links on the DRAT website and replaces them with a single [Mattmann AI](http://mattmann.ai) link.