### PR TITLE
Speak Avro to the resource manager, not XML-RPC

### DIFF
--- a/filemgr/src/main/resources/etc/filemgr.properties
+++ b/filemgr/src/main/resources/etc/filemgr.properties
@@ -32,6 +32,9 @@ filemgr.datatransfer.factory=org.apache.oodt.cas.filemgr.datatransfer.LocalDataT
 filemgr.validationLayer.factory=org.apache.oodt.cas.filemgr.validation.XMLValidationLayerFactory
 
 # xml rpc client configuration
+# Read only by the XML-RPC client. This deployment selects Avro above, so
+# these have no effect; they are kept for anyone who switches back before
+# XML-RPC is removed from Mnemosyne altogether.
 org.apache.oodt.cas.filemgr.system.xmlrpc.connectionTimeout.minutes=20
 org.apache.oodt.cas.filemgr.system.xmlrpc.requestTimeout.minutes=60
 #org.apache.oodt.cas.filemgr.system.xmlrpc.connection.retries=0

--- a/resmgr/src/main/resources/bin/batch_stub
+++ b/resmgr/src/main/resources/bin/batch_stub
@@ -28,6 +28,6 @@ else
         java -cp "../lib/*" \
         -Dorg.apache.oodt.cas.pge.task.metkeys.legacyMode="true" \
         -Dorg.apache.oodt.cas.pge.task.status.legacyMode="true" \
-        org.apache.oodt.cas.resource.system.extern.XmlRpcBatchStub \
+        org.apache.oodt.cas.resource.system.extern.AvroRpcBatchStub \
         --portNum $1&
 endif

--- a/resmgr/src/main/resources/bin/resmgr
+++ b/resmgr/src/main/resources/bin/resmgr
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# init script for XmlRpcResourceManager
+# init script for the resource manager
 #
 # chkconfig: 345 88 22
 # description: CAS Resource Manager

--- a/resmgr/src/main/resources/bin/resmgr-client
+++ b/resmgr/src/main/resources/bin/resmgr-client
@@ -31,4 +31,4 @@ $JAVA_HOME/bin/java \
         -Dorg.apache.oodt.cas.cli.action.spring.config=../policy/cmd-line-actions.xml \
         -Dorg.apache.oodt.cas.cli.option.spring.config=../policy/cmd-line-options.xml \
         -cp "../lib/*" \
-        org.apache.oodt.cas.resource.system.XmlRpcResourceManagerClient $*
+        org.apache.oodt.cas.resource.system.ResourceManagerClientMain $*

--- a/resmgr/src/main/resources/etc/resource.properties
+++ b/resmgr/src/main/resources/etc/resource.properties
@@ -16,8 +16,15 @@
 #
 # Properties required to configure the Resource Manager
 
+# RPC implementation for the resource manager itself
+resmgr.manager=org.apache.oodt.cas.resource.system.AvroRpcResourceManager
+resmgr.manager.client=org.apache.oodt.cas.resource.system.AvroRpcResourceManagerClient
+
 # resource batchmgr factory
-resource.batchmgr.factory = org.apache.oodt.cas.resource.batchmgr.XmlRpcBatchMgrFactory
+# Avro. XML-RPC is on its way out of Mnemosyne: Apache XML-RPC has had no
+# release in over a decade and is the last thing keeping commons-httpclient
+# 3.x, and its unfixed CVE-2012-5783, on the classpath.
+resource.batchmgr.factory = org.apache.oodt.cas.resource.batchmgr.AvroRpcBatchMgrFactory
 
 # resource monitor factory
 resource.monitor.factory = org.apache.oodt.cas.resource.monitor.AssignmentMonitorFactory
@@ -44,6 +51,7 @@ org.apache.oodt.cas.resource.jobqueue.jobstack.maxstacksize=1000
 org.apache.oodt.cas.resource.scheduler.wait.seconds=20
 
 # XML-RPC configuration props
+# Read only by the XML-RPC client, which is no longer selected above.
 org.apache.oodt.cas.resource.system.xmlrpc.requestTimeout.minutes=20
 org.apache.oodt.cas.resource.system.xmlrpc.connectionTimeout.minutes=60
 


### PR DESCRIPTION
First step of [mnemosyne#93](https://github.com/chrismattmann/mnemosyne/issues/93) — retiring XML-RPC.

## What changed

The file manager and workflow manager were **already** on Avro here. The resource manager was the last holdout:

| | was | now |
|---|---|---|
| `resource.batchmgr.factory` | `XmlRpcBatchMgrFactory` | `AvroRpcBatchMgrFactory` |
| `batch_stub` | `XmlRpcBatchStub` | `AvroRpcBatchStub` |
| `resmgr-client` | `XmlRpcResourceManagerClient` | `ResourceManagerClientMain` |
| `resmgr.manager` / `.client` | unset, default decided | named explicitly |

`resmgr-client` now goes through the factory rather than naming one implementation, so this deployment follows what its configuration says instead of whatever class the script happened to launch. The Avro batch stub takes the same `--portNum` argument, so the scripts are a drop-in swap.

## Why this first

Apache XML-RPC has had no release in over a decade, and it is the last thing keeping `commons-httpclient` 3.x on the classpath along with **CVE-2012-5783**, which has no fixed version because the library was abandoned before anyone addressed it.

Moving the deployments across *before* removing the transport means that when something breaks there is one candidate cause, not two.

## Verification

Checked in the **built tarball**, not just the source:

```
resmgr/etc/resource.properties:
  resmgr.manager=...AvroRpcResourceManager
  resmgr.manager.client=...AvroRpcResourceManagerClient
  resource.batchmgr.factory = ...AvroRpcBatchMgrFactory

resmgr/bin/batch_stub  ->  ...resource.system.extern.AvroRpcBatchStub
```

- `mvn -B clean package`: **BUILD SUCCESS**
- `mvn -B clean test`: **12 tests, 0 failures**
- no uncommented `XmlRpc` reference remains in any DRAT source or config

## What this does not do

`commons-httpclient` **still resolves here, eight times**. DRAT builds against the published `cas-resource:1.11.0`, which still declares it. Nothing in this deployment calls it any more, but the jar goes away only when Mnemosyne removes XML-RPC and releases — step 3 of the tracking issue.

The `xmlrpc.*` timeout properties are kept and labelled. They are read only by the XML-RPC client, which is no longer selected, so they currently do nothing.