### PR TITLE
Use SolrJ's own API rather than a class that arrives by accident

### DIFF
--- a/proteus/src/main/java/backend/ProcessDratWrapper.java
+++ b/proteus/src/main/java/backend/ProcessDratWrapper.java
@@ -27,7 +27,7 @@ import org.apache.commons.lang.time.DurationFormatUtils;
 import org.apache.oodt.cas.crawl.MetExtractorProductCrawler;
 import org.apache.oodt.cas.workflow.structs.WorkflowInstance;
 import org.apache.solr.client.solrj.SolrServerException;
-import org.apache.solr.client.solrj.impl.CommonsHttpSolrServer;
+import org.apache.solr.client.solrj.impl.HttpSolrServer;
 import org.apache.oodt.cas.filemgr.structs.Product;
 import org.apache.oodt.cas.filemgr.structs.ProductPage;
 import org.apache.oodt.cas.filemgr.structs.ProductType;
@@ -737,9 +737,9 @@ public class ProcessDratWrapper extends GenericProcess
   private synchronized void wipeSolrCore(String coreName) {
     String baseUrl = "http://localhost:8080/solr";
     String finalUrl = baseUrl + "/" + coreName;
-    CommonsHttpSolrServer server = null;
+    HttpSolrServer server = null;
     try {
-      server = new CommonsHttpSolrServer(finalUrl);
+      server = new HttpSolrServer(finalUrl);
       server.deleteByQuery("*:*");
       server.commit();
     } catch (Exception e) {
@@ -748,7 +748,10 @@ public class ProcessDratWrapper extends GenericProcess
           + e.getLocalizedMessage());
     } finally {
       if (server != null) {
-        server.getHttpClient().getHttpConnectionManager().closeIdleConnections(0);
+        // was getHttpClient().getHttpConnectionManager().closeIdleConnections(0),
+        // which is commons-httpclient 3.x; SolrJ 4 returns an HttpComponents
+        // client and releases its connections through shutdown()
+        server.shutdown();
       }
     }
   }


### PR DESCRIPTION
**This will break DRAT's build when Mnemosyne next releases.** It is not broken today, and the reason is worth stating precisely.

`ProcessDratWrapper` imports `org.apache.solr.client.solrj.impl.CommonsHttpSolrServer`. proteus declares `solr-solrj 4.2.1`, and **that class is not in it** — it was removed in Solr 4.0 and replaced by `HttpSolrServer`:

```
$ unzip -l solr-solrj-4.2.1.jar | grep SolrServer
  CloudSolrServer.class  ConcurrentUpdateSolrServer.class
  HttpSolrServer.class   LBHttpSolrServer.class
```

The build works because the class arrives from **somewhere else entirely**. Mnemosyne pulls in `solr-core 1.3.0`, and the 2008 `solr-core` jar happens to contain `org.apache.solr.client.solrj.impl.CommonsHttpSolrServer`:

```
$ unzip -l solr-core-1.3.0.jar | grep -c CommonsHttpSolrServer.class
1
```

So proteus has been compiling against a class supplied by a transitive dependency of a dependency, not by the SolrJ it actually asks for.

### Why that ends

chrismattmann/mnemosyne#87 removes `solr-core`: nothing there ever ran a Solr server, only the client, and carrying the server meant carrying `commons-httpclient` 3.x and **CVE-2012-5783** with it. When that release lands, the class disappears. Building DRAT against a locally installed Mnemosyne reproduces it exactly:

```
ProcessDratWrapper.java:[30,41] cannot find symbol
  symbol:   class CommonsHttpSolrServer
  location: package org.apache.solr.client.solrj.impl
```

Six errors, on `master`, with no DRAT changes at all.

### The fix

`HttpSolrServer` is the replacement and is present in the 4.2.1 proteus already declares — so this is a rename plus one cleanup call. The `finally` block called:

```java
server.getHttpClient().getHttpConnectionManager().closeIdleConnections(0);
```

which is commons-httpclient 3.x API. SolrJ 4 returns an HttpComponents client instead and releases its connections through `shutdown()`.

**No version bump.** DRAT stays on `solr-solrj 4.2.1` and simply stops relying on a seventeen-year-old jar to supply a class for it.

CI here still resolves the published Mnemosyne, so it should stay green either way — the point is that it will also stay green *after* the next Mnemosyne release.