### PR TITLE
Restore proper logging configuration

### DIFF
--- a/crawler/src/main/assembly/assembly.xml
+++ b/crawler/src/main/assembly/assembly.xml
@@ -34,6 +34,7 @@
       <outputDirectory>crawler/etc</outputDirectory>
       <includes>
         <include>**.properties</include>
+        <include>**.xml</include>
       </includes>
     </fileSet>
     <fileSet>

--- a/crawler/src/main/resources/bin/crawlctl
+++ b/crawler/src/main/resources/bin/crawlctl
@@ -15,4 +15,4 @@
 # under the License.    
 ##########################################################################
 
-java -Djava.util.logging.config.file=../etc/logging.properties -cp "../lib/*" org.apache.oodt.cas.crawl.daemon.CrawlDaemonController $@
+java -Dlog4j.configurationFile=../etc/log4j2.xml -Djava.util.logging.config.file=../etc/logging.properties -cp "../lib/*" org.apache.oodt.cas.crawl.daemon.AvroRpcCrawlDaemonController $@

--- a/crawler/src/main/resources/bin/crawler_launcher
+++ b/crawler/src/main/resources/bin/crawler_launcher
@@ -68,6 +68,7 @@ fi
 cd "$CRAWLER_HOME"/bin
 
 "$_RUNJAVA" $JAVA_OPTS $OODT_OPTS \
+   -Dlog4j.configurationFile="$CRAWLER_HOME"/etc/log4j2.xml \
    -Djava.util.logging.config.file="$CRAWLER_HOME"/etc/logging.properties \
    -Dorg.apache.oodt.cas.filemgr.properties="$FILEMGR_HOME"/etc/filemgr.properties \
    -Dorg.apache.oodt.cas.crawl.bean.repo=file:"$CRAWLER_HOME"/policy/crawler-config.xml \

--- a/crawler/src/main/resources/etc/log4j2.xml
+++ b/crawler/src/main/resources/etc/log4j2.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Logging configuration for the DRAT crawler.
+
+  The console carries only what someone needs to act on, and writes to stderr:
+  several DRAT steps pipe one OODT tool into another, and anything on stdout is
+  read as data. The file appender keeps the full record.
+
+  The start script points at this file with -Dlog4j.configurationFile. Without
+  it log4j2 falls back to its default, which is ERROR to the console and no
+  file appender at all.
+-->
+<Configuration status="WARN">
+
+    <Appenders>
+        <Console name="Console" target="SYSTEM_ERR">
+            <ThresholdFilter level="error" onMatch="ACCEPT" onMismatch="DENY"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
+        <File name="File" fileName="../logs/cas_crawler.log" immediateFlush="true">
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </File>
+    </Appenders>
+
+    <Loggers>
+        <Logger name="org.springframework" level="error"/>
+        <Logger name="org.mortbay" level="error"/>
+        <Logger name="org.apache.avro.ipc" level="warn"/>
+        <Logger name="org.jboss.netty" level="warn"/>
+
+        <Root level="info">
+            <AppenderRef ref="Console"/>
+            <AppenderRef ref="File"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/crawler/src/main/resources/etc/logging.properties
+++ b/crawler/src/main/resources/etc/logging.properties
@@ -20,12 +20,10 @@
 handlers = java.util.logging.ConsoleHandler, java.util.logging.FileHandler
 
 # Set the default logging level for the root logger
-.level = ALL
-    
+.level = INFO
 # Set the default logging level for new ConsoleHandler instances
-java.util.logging.ConsoleHandler.level = ALL
-java.util.logging.FileHandler.level = ALL
-        
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.FileHandler.level = INFO
 # Set the default formatter for new ConsoleHandler instances
 java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
 
@@ -38,21 +36,11 @@ java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
     
 # Set the default logging level for the subsystems
 
-org.apache.oodt.cas.crawl.level = ALL
-
-org.apache.oodt.cas.crawl.action.level = ALL
-
-org.apache.oodt.cas.crawl.typedetection.level = ALL
-
-org.apache.oodt.cas.crawl.util.level = ALL
-
-org.apache.oodt.cas.crawl.config.level = ALL
-
-# control the underlying commons-httpclient transport layer for xmlrpc 
-org.apache.commons.httpclient.level = INFO
-httpclient.wire.header.level = INFO
-httpclient.wire.level = INFO
-
+org.apache.oodt.cas.crawl.level = INFO
+org.apache.oodt.cas.crawl.action.level = INFO
+org.apache.oodt.cas.crawl.typedetection.level = INFO
+org.apache.oodt.cas.crawl.util.level = INFO
+org.apache.oodt.cas.crawl.config.level = INFO
 org.springframework.beans.level = SEVERE
 org.springframework.core.level = SEVERE
 org.springframework.level = SEVERE

--- a/filemgr/src/main/resources/bin/filemgr
+++ b/filemgr/src/main/resources/bin/filemgr
@@ -81,6 +81,7 @@ if [ "$1" = "start" ]; then
   cd "$FILEMGR_HOME"/bin
   
   "$_RUNJAVA" $JAVA_OPTS $OODT_OPTS \
+    -Dlog4j.configurationFile="$FILEMGR_HOME"/etc/log4j2.xml \
     -Djava.util.logging.config.file="$FILEMGR_HOME"/etc/logging.properties \
     -Dorg.apache.oodt.cas.filemgr.properties="$FILEMGR_HOME"/etc/filemgr.properties \
     -Djava.io.tmpdir="$OODT_TMPDIR" \

--- a/filemgr/src/main/resources/bin/filemgr-client
+++ b/filemgr/src/main/resources/bin/filemgr-client
@@ -70,6 +70,7 @@ cd "$FILEMGR_HOME"/bin
 
 "$_RUNJAVA" $JAVA_OPTS $OODT_OPTS \
   -Dorg.apache.oodt.cas.filemgr.properties="$FILEMGR_HOME"/etc/filemgr.properties \
+  -Dlog4j.configurationFile="$FILEMGR_HOME"/etc/log4j2.xml \
   -Djava.util.logging.config.file="$FILEMGR_HOME"/etc/logging.properties \
   -Dorg.apache.oodt.cas.cli.action.spring.config=file:"$FILEMGR_HOME"/policy/cmd-line-actions.xml \
   -Dorg.apache.oodt.cas.cli.option.spring.config=file:"$FILEMGR_HOME"/policy/cmd-line-options.xml \

--- a/filemgr/src/main/resources/bin/query-tool
+++ b/filemgr/src/main/resources/bin/query-tool
@@ -74,6 +74,7 @@ cd "$FILEMGR_HOME"/bin
 
 "$_RUNJAVA" $JAVA_OPTS $OODT_OPTS \
   -Dorg.apache.oodt.cas.filemgr.properties="$FILEMGR_HOME"/etc/filemgr.properties \
+  -Dlog4j.configurationFile="$FILEMGR_HOME"/etc/log4j2.xml \
   -Djava.util.logging.config.file="$FILEMGR_HOME"/etc/logging.properties \
   -cp "$FILEMGR_HOME/lib/*" \
   org.apache.oodt.cas.filemgr.tools.QueryTool "$@"

--- a/filemgr/src/main/resources/etc/log4j2.xml
+++ b/filemgr/src/main/resources/etc/log4j2.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Logging configuration for the DRAT filemgr.
+
+  The console carries only what someone needs to act on, and writes to stderr:
+  several DRAT steps pipe one OODT tool into another, and anything on stdout is
+  read as data. The file appender keeps the full record.
+
+  The start script points at this file with -Dlog4j.configurationFile. Without
+  it log4j2 falls back to its default, which is ERROR to the console and no
+  file appender at all.
+-->
+<Configuration status="WARN">
+
+    <Appenders>
+        <Console name="Console" target="SYSTEM_ERR">
+            <ThresholdFilter level="error" onMatch="ACCEPT" onMismatch="DENY"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
+        <File name="File" fileName="../logs/cas_filemgr.log" immediateFlush="true">
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </File>
+    </Appenders>
+
+    <Loggers>
+        <Logger name="org.springframework" level="error"/>
+        <Logger name="org.mortbay" level="error"/>
+        <Logger name="org.apache.avro.ipc" level="warn"/>
+        <Logger name="org.jboss.netty" level="warn"/>
+
+        <Root level="info">
+            <AppenderRef ref="Console"/>
+            <AppenderRef ref="File"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/filemgr/src/main/resources/etc/logging.properties
+++ b/filemgr/src/main/resources/etc/logging.properties
@@ -19,12 +19,10 @@
 handlers = java.util.logging.ConsoleHandler, java.util.logging.FileHandler
 
 # Set the default logging level for the root logger
-.level = ALL
-    
+.level = INFO
 # Set the default logging level for new ConsoleHandler instances
-java.util.logging.ConsoleHandler.level = ALL
-java.util.logging.FileHandler.level = ALL
-        
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.FileHandler.level = INFO
 # Set the default formatter for new ConsoleHandler instances
 java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
 
@@ -41,8 +39,7 @@ java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
 org.apache.oodt.cas.filemgr.catalog.level = INFO
 
 # repository subsystem
-org.apache.oodt.cas.filemgr.repository.level = FINE
-
+org.apache.oodt.cas.filemgr.repository.level = INFO
 # system subsystem
 org.apache.oodt.cas.filemgr.system.level = INFO
 
@@ -50,15 +47,10 @@ org.apache.oodt.cas.filemgr.system.level = INFO
 org.apache.oodt.cas.filemgr.versioning.level = INFO
 
 # data transfer subsystem
-org.apache.oodt.cas.filemgr.datatransfer.level = FINE
-
+org.apache.oodt.cas.filemgr.datatransfer.level = INFO
 # util
 org.apache.oodt.cas.filemgr.util.level = INFO
 
 # validation
 org.apache.oodt.cas.filemgr.validation.level = INFO
 
-# control the underlying commons-httpclient transport layer for xmlrpc
-org.apache.commons.httpclient.level = INFO
-httpclient.wire.header.level = INFO
-httpclient.wire.level = INFO

--- a/pcs/src/main/resources/bin/pcs_ll
+++ b/pcs/src/main/resources/bin/pcs_ll
@@ -41,7 +41,8 @@ cd $DIR
 set DIR_PATH = `pwd`
 cd $ORIG_DIR
 
-java -Djava.util.logging.config.file=$DIR_PATH/../etc/logging.properties \
+java -Dlog4j.configurationFile=$DIR_PATH/../etc/log4j2.xml \
+     -Djava.util.logging.config.file=$DIR_PATH/../etc/logging.properties \
     -cp "$DIR_PATH/../lib/*:$DIR_PATH/../../filemgr/lib/*:$DIR_PATH/../../workflow/lib/*" \
 	org.apache.oodt.pcs.tools.PCSLongLister \
 	$FILEMGR_URL $DIR_PATH/../policy/pcs-ll-conf.xml $argv[2-$#argv]

--- a/pcs/src/main/resources/bin/pcs_stat
+++ b/pcs/src/main/resources/bin/pcs_stat
@@ -67,7 +67,8 @@ cd $DIR
 set DIR_PATH = `pwd`
 cd $ORIG_DIR
 
-java -Djava.util.logging.config.file=$DIR_PATH/../etc/logging.properties \
+java -Dlog4j.configurationFile=$DIR_PATH/../etc/log4j2.xml \
+     -Djava.util.logging.config.file=$DIR_PATH/../etc/logging.properties \
     -Dorg.apache.oodt.cas.filemgr.properties=$DIR_PATH/../../filemgr/etc/filemgr.properties \
     -cp "$DIR_PATH/../lib/*:$DIR_PATH/../../filemgr/lib/*:$DIR_PATH/../workflow/lib/*:$DIR_PATH/../../resmgr/lib/*" \
 	org.apache.oodt.pcs.tools.PCSHealthMonitor \

--- a/pcs/src/main/resources/bin/pcs_trace
+++ b/pcs/src/main/resources/bin/pcs_trace
@@ -30,7 +30,8 @@ if ( $#argv != 1 ) then
 	exit 1
 else
 	java -cp "$DIR_PATH/../lib/*:$DIR_PATH/../../filemgr/lib/*:$DIR_PATH/../../workflow/lib/*" \
-    -Djava.util.logging.config.file=$DIR_PATH/../etc/logging.properties \
+    -Dlog4j.configurationFile=$DIR_PATH/../etc/log4j2.xml \
+     -Djava.util.logging.config.file=$DIR_PATH/../etc/logging.properties \
     -Dorg.apache.oodt.cas.filemgr.properties=$DIR_PATH/../../filemgr/etc/filemgr.properties \
 	org.apache.oodt.pcs.tools.PCSTrace \
 	--fm $FILEMGR_URL \

--- a/pcs/src/main/resources/etc/log4j2.xml
+++ b/pcs/src/main/resources/etc/log4j2.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Logging configuration for the DRAT pcs.
+
+  The console carries only what someone needs to act on, and writes to stderr:
+  several DRAT steps pipe one OODT tool into another, and anything on stdout is
+  read as data. The file appender keeps the full record.
+
+  The start script points at this file with -Dlog4j.configurationFile. Without
+  it log4j2 falls back to its default, which is ERROR to the console and no
+  file appender at all.
+-->
+<Configuration status="WARN">
+
+    <Appenders>
+        <Console name="Console" target="SYSTEM_ERR">
+            <ThresholdFilter level="error" onMatch="ACCEPT" onMismatch="DENY"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
+        <File name="File" fileName="../logs/cas_pcs.log" immediateFlush="true">
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </File>
+    </Appenders>
+
+    <Loggers>
+        <Logger name="org.springframework" level="error"/>
+        <Logger name="org.mortbay" level="error"/>
+        <Logger name="org.apache.avro.ipc" level="warn"/>
+        <Logger name="org.jboss.netty" level="warn"/>
+
+        <Root level="info">
+            <AppenderRef ref="Console"/>
+            <AppenderRef ref="File"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/pcs/src/main/resources/etc/logging.properties
+++ b/pcs/src/main/resources/etc/logging.properties
@@ -19,11 +19,9 @@
 handlers = java.util.logging.ConsoleHandler
 
 # Set the default logging level for the root logger
-.level = ALL
-    
+.level = INFO
 # Set the default logging level for new ConsoleHandler instances
-java.util.logging.ConsoleHandler.level = ALL
-        
+java.util.logging.ConsoleHandler.level = SEVERE
 # Set the default formatter for new ConsoleHandler instances
 java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
     
@@ -40,9 +38,5 @@ org.apache.oodt.cas.pge.util.level = OFF
 org.apache.oodt.cas.workflow.system.level = OFF
 org.apache.oodt.cas.workflow.instrepo.level = OFF
 
-# control the underlying commons-httpclient transport layer for xmlrpc 
-org.apache.commons.httpclient.level = OFF
-httpclient.wire.header.level = OFF
-httpclient.wire.level = OFF
 sun.net.www.protocol.http.level = OFF
 

--- a/resmgr/src/main/resources/bin/resmgr
+++ b/resmgr/src/main/resources/bin/resmgr
@@ -87,6 +87,7 @@ if [ "$1" = "start" ]; then
   cd "$RESMGR_HOME"/bin
 
   "$_RUNJAVA" $JAVA_OPTS $OODT_OPTS \
+    -Dlog4j.configurationFile="$RESMGR_HOME"/etc/log4j2.xml \
     -Djava.util.logging.config.file="$RESMGR_HOME"/etc/logging.properties \
     -Dorg.apache.oodt.cas.resource.properties="$RESMGR_HOME"/etc/resource.properties \
     -Djava.io.tmpdir="$OODT_TMPDIR" \

--- a/resmgr/src/main/resources/bin/resmgr-client
+++ b/resmgr/src/main/resources/bin/resmgr-client
@@ -27,7 +27,7 @@ export JAVA_HOME
 
 $JAVA_HOME/bin/java \
         -Dorg.apache.oodt.cas.resource.properties=../etc/resource.properties \
-        -Djava.util.logging.config.file=../etc/logging.properties \
+        -Dlog4j.configurationFile=../etc/log4j2.xml -Djava.util.logging.config.file=../etc/logging.properties \
         -Dorg.apache.oodt.cas.cli.action.spring.config=../policy/cmd-line-actions.xml \
         -Dorg.apache.oodt.cas.cli.option.spring.config=../policy/cmd-line-options.xml \
         -cp "../lib/*" \

--- a/resmgr/src/main/resources/etc/log4j2.xml
+++ b/resmgr/src/main/resources/etc/log4j2.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Logging configuration for the DRAT resmgr.
+
+  The console carries only what someone needs to act on, and writes to stderr:
+  several DRAT steps pipe one OODT tool into another, and anything on stdout is
+  read as data. The file appender keeps the full record.
+
+  The start script points at this file with -Dlog4j.configurationFile. Without
+  it log4j2 falls back to its default, which is ERROR to the console and no
+  file appender at all.
+-->
+<Configuration status="WARN">
+
+    <Appenders>
+        <Console name="Console" target="SYSTEM_ERR">
+            <ThresholdFilter level="error" onMatch="ACCEPT" onMismatch="DENY"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
+        <File name="File" fileName="../logs/cas_resource.log" immediateFlush="true">
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </File>
+    </Appenders>
+
+    <Loggers>
+        <Logger name="org.springframework" level="error"/>
+        <Logger name="org.mortbay" level="error"/>
+        <Logger name="org.apache.avro.ipc" level="warn"/>
+        <Logger name="org.jboss.netty" level="warn"/>
+
+        <Root level="info">
+            <AppenderRef ref="Console"/>
+            <AppenderRef ref="File"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/resmgr/src/main/resources/etc/logging.properties
+++ b/resmgr/src/main/resources/etc/logging.properties
@@ -20,12 +20,10 @@
 handlers = java.util.logging.ConsoleHandler, java.util.logging.FileHandler
 
 # Set the default logging level for the root logger
-.level = ALL
-    
+.level = INFO
 # Set the default logging level for new ConsoleHandler instances
-java.util.logging.ConsoleHandler.level = ALL
-java.util.logging.FileHandler.level = ALL
-        
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.FileHandler.level = INFO
 # Set the default formatter for new ConsoleHandler instances
 java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
 
@@ -51,13 +49,7 @@ org.apache.oodt.cas.resource.jobqueue.level = INFO
 org.apache.oodt.cas.resource.scheduler.level = INFO
 
 # system subsystem
-org.apache.oodt.cas.resource.system.level = FINE
-
-# control the underlying commons-httpclient transport layer for xmlrpc 
-org.apache.commons.httpclient.level = INFO
-httpclient.wire.header.level = INFO
-httpclient.wire.level = INFO
-
+org.apache.oodt.cas.resource.system.level = INFO
 # spring framework logging
 org.springframework.beans.level = SEVERE
 org.springframework.core.level = SEVERE

--- a/workflow/src/main/resources/bin/wmgr
+++ b/workflow/src/main/resources/bin/wmgr
@@ -80,6 +80,7 @@ if [ "$1" = "start" ]; then
   cd "$WORKFLOW_HOME"/bin
 
   "$_RUNJAVA" $JAVA_OPTS $OODT_OPTS \
+    -Dlog4j.configurationFile="$WORKFLOW_HOME"/etc/log4j2.xml \
     -Djava.util.logging.config.file="$WORKFLOW_HOME"/etc/logging.properties \
     -Dorg.apache.oodt.cas.workflow.properties="$WORKFLOW_HOME"/etc/workflow.properties \
     -Djava.io.tmpdir="$OODT_TMPDIR" \

--- a/workflow/src/main/resources/bin/wmgr-client
+++ b/workflow/src/main/resources/bin/wmgr-client
@@ -68,6 +68,7 @@ fi
 cd "$WORKFLOW_HOME"/bin
 
 "$_RUNJAVA" $JAVA_OPTS $OODT_OPTS \
+  -Dlog4j.configurationFile="$WORKFLOW_HOME"/etc/log4j2.xml \
   -Djava.util.logging.config.file="$WORKFLOW_HOME"/etc/logging.properties \
   -Dorg.apache.oodt.cas.cli.action.spring.config=file:"$WORKFLOW_HOME"/policy/cmd-line-actions.xml \
   -Dorg.apache.oodt.cas.cli.option.spring.config=file:"$WORKFLOW_HOME"/policy/cmd-line-options.xml \

--- a/workflow/src/main/resources/etc/log4j2.xml
+++ b/workflow/src/main/resources/etc/log4j2.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Logging configuration for the DRAT workflow.
+
+  The console carries only what someone needs to act on, and writes to stderr:
+  several DRAT steps pipe one OODT tool into another, and anything on stdout is
+  read as data. The file appender keeps the full record.
+
+  The start script points at this file with -Dlog4j.configurationFile. Without
+  it log4j2 falls back to its default, which is ERROR to the console and no
+  file appender at all.
+-->
+<Configuration status="WARN">
+
+    <Appenders>
+        <Console name="Console" target="SYSTEM_ERR">
+            <ThresholdFilter level="error" onMatch="ACCEPT" onMismatch="DENY"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
+        <File name="File" fileName="../logs/cas_workflow.log" immediateFlush="true">
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </File>
+    </Appenders>
+
+    <Loggers>
+        <Logger name="org.springframework" level="error"/>
+        <Logger name="org.mortbay" level="error"/>
+        <Logger name="org.apache.avro.ipc" level="warn"/>
+        <Logger name="org.jboss.netty" level="warn"/>
+
+        <Root level="info">
+            <AppenderRef ref="Console"/>
+            <AppenderRef ref="File"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/workflow/src/main/resources/etc/logging.properties
+++ b/workflow/src/main/resources/etc/logging.properties
@@ -19,12 +19,10 @@
 handlers = java.util.logging.ConsoleHandler, java.util.logging.FileHandler
 
 # Set the default logging level for the root logger
-.level = ALL
-    
+.level = INFO
 # Set the default logging level for new ConsoleHandler instances
-java.util.logging.ConsoleHandler.level = ALL
-java.util.logging.FileHandler.level = ALL
-        
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.FileHandler.level = INFO
 # Set the default formatter for new ConsoleHandler instances
 java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
 
@@ -50,12 +48,7 @@ org.apache.oodt.cas.workflow.instrepo.level = INFO
 org.apache.oodt.cas.workflow.repository.level = INFO
 
 # system subsystem
-org.apache.oodt.cas.workflow.system.level = FINE
-
-# control the underlying commons-httpclient transport layer for xmlrpc 
-org.apache.commons.httpclient.level = INFO
-httpclient.wire.header.level = INFO
-httpclient.wire.level = INFO
+org.apache.oodt.cas.workflow.system.level = INFO
 sun.net.level = OFF
 sun.net.www.level = OFF
 


### PR DESCRIPTION
Mirrors chrismattmann/bigtranslate#31. Three problems, the same as there.

## Levels

All five `etc/logging.properties` shipped `.level = ALL`, with the console and file handlers at `ALL` too. `ALL` means FINE, FINER and FINEST — that is the noise. Now `INFO`, console at `SEVERE`.

## There was no log4j2 configuration for the services

OODT routes slf4j through log4j2. DRAT shipped a `log4j2.xml` only for Proteus, and no script passed `-Dlog4j.configurationFile`. Service logging was therefore configured by whichever `log4j2.xml` happened to be first on the classpath — one packaged inside `cas-workflow`, set to `<Root level="debug">` writing to `SYSTEM_OUT`.

Worth fixing on its own, and **chrismattmann/mnemosyne#96 makes it necessary**: library jars no longer carry logging configuration, so without our own we fall back to log4j2's default — errors to console, **no file appender at all** — and lose the on-disk record.

Each component now has an `etc/log4j2.xml`: root `info`, console gated to errors and pointed at **stderr**, file appender keeping the full record. Stderr matters because DRAT pipes one OODT tool into another and anything on stdout is read as data — in BigTranslate that exact pattern fed a Netty debug line into `DeleteProduct` where a product id belonged.

All **12** scripts pass `-Dlog4j.configurationFile` beside the `-Djava.util.logging.config.file` they already passed. Nine are `/bin/sh`, three are `/bin/tcsh`; both were checked with their own shell rather than assuming.

## Two things found while doing it

**`crawlctl` named a deleted class.** It invoked `org.apache.oodt.cas.crawl.daemon.CrawlDaemonController`, removed with XML-RPC in chrismattmann/mnemosyne#95 — `ClassNotFoundException` the first time anyone controlled a crawl daemon after upgrading. Now `AvroRpcCrawlDaemonController`.

**The crawler assembly matched only `**.properties` for `etc/`**, so its new `log4j2.xml` would not have shipped at all. Same gap BigTranslate had.

## Verified against the built tarball

Not the source tree — that is how the crawler gap was found:

| Component | `etc/log4j2.xml` | `etc/logging.properties` |
|---|---|---|
| filemgr, workflow, resmgr, crawler, pcs | ✅ all five | ✅ all five |

## Note

Building this locally against a Mnemosyne that already has chrismattmann/mnemosyne#87 in it fails in `proteus`, for reasons unrelated to this PR — see #212. CI here resolves the published Mnemosyne and is unaffected.