### PR TITLE
Bundle Solr 10 and start it from bin/oodt

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -14,6 +14,7 @@
  
   <properties>
     <tomcat.version>9.0.7</tomcat.version>
+    <solr.version>10.0.0</solr.version>
   </properties>
 
   <dependencies>
@@ -225,6 +226,39 @@
         same phase run in declaration order, and the Tomcat unpack would
         otherwise put the stock page back.
       -->
+      <!--
+        Solr ships as a standalone application with its own Jetty; it stopped
+        publishing a war, and its distribution is not on Maven Central, so it
+        cannot be fetched with dependency:unpack the way Tomcat is above.
+        Downloaded once and cached: skipexisting keeps rebuilds from pulling
+        343MB again.
+      -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>3.1.0</version>
+        <executions>
+          <execution>
+            <id>fetch-solr</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target>
+                <get src="https://archive.apache.org/dist/solr/solr/${solr.version}/solr-${solr.version}.tgz"
+                     dest="${project.build.directory}/solr-${solr.version}.tgz"
+                     skipexisting="true"
+                     verbose="false"/>
+                <untar src="${project.build.directory}/solr-${solr.version}.tgz"
+                       dest="${project.build.directory}"
+                       compression="gzip"/>
+                <chmod dir="${project.build.directory}/solr-${solr.version}/bin" perm="755" includes="*"/>
+              </target>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>

--- a/distribution/src/main/assembly/assembly.xml
+++ b/distribution/src/main/assembly/assembly.xml
@@ -107,6 +107,24 @@
       <fileMode>775</fileMode>
       <directoryMode>775</directoryMode>
     </fileSet>
+    <!--
+      The Solr server, unpacked from the distribution antrun fetched. Kept
+      separate from solr/, which is the Solr home holding DRAT's cores and
+      their data: this directory is the engine and can be replaced wholesale
+      on the next Solr upgrade.
+    -->
+    <fileSet>
+      <directory>${project.build.directory}/solr-${solr.version}</directory>
+      <outputDirectory>solr-server</outputDirectory>
+      <excludes>
+        <exclude>bin/**</exclude>
+      </excludes>
+    </fileSet>
+    <fileSet>
+      <directory>${project.build.directory}/solr-${solr.version}/bin</directory>
+      <outputDirectory>solr-server/bin</outputDirectory>
+      <fileMode>0755</fileMode>
+    </fileSet>
   </fileSets>
   <dependencySets>
     <dependencySet>

--- a/distribution/src/main/resources/bin/oodt
+++ b/distribution/src/main/resources/bin/oodt
@@ -66,6 +66,9 @@ WORKFLOW_EXEC=wmgr
 RESMGR_EXEC=resmgr
 FILEMGR_EXEC=filemgr
 TOMCAT_EXEC=catalina.sh
+SOLR_EXEC=solr
+SOLR_SERVER_HOME="$OODT_BASE"/solr-server
+SOLR_PORT=${SOLR_PORT:-8983}
 
 cleanup_stale_pid() {
   pid_file="$1"
@@ -115,6 +118,13 @@ if [ "$1" = "start" ]; then
   nohup "$WORKFLOW_HOME"/bin/"$WORKFLOW_EXEC" start "$@" >> "$OODT_OUT" 2>&1  &
   nohup "$RESMGR_HOME"/bin/"$RESMGR_EXEC" start "$@" >> "$OODT_OUT" 2>&1  &
   nohup "$OODT_BASE"/tomcat/bin/"$TOMCAT_EXEC" start "$@" >> "$OODT_OUT" 2>&1 &
+  # Solr runs as its own application now, with its own Jetty, rather than as a
+  # war inside Tomcat. --solr-home points it at DRAT's cores; --user-managed
+  # keeps it out of SolrCloud mode, which DRAT does not use.
+  if [ -x "$SOLR_SERVER_HOME"/bin/"$SOLR_EXEC" ]; then
+    nohup "$SOLR_SERVER_HOME"/bin/"$SOLR_EXEC" start -p "$SOLR_PORT" \
+      --solr-home "$OODT_BASE"/solr --user-managed >> "$OODT_OUT" 2>&1 &
+  fi
   sleep 2
 # Print confirmation messages to the end user
 # FileManager
@@ -175,6 +185,9 @@ elif [ "$1" = "stop" ]; then
   "$WORKFLOW_HOME"/bin/"$WORKFLOW_EXEC" stop "$@" >> "$OODT_OUT" 2>&1 &
   "$RESMGR_HOME"/bin/"$RESMGR_EXEC" stop "$@" >> "$OODT_OUT" 2>&1 &
   "$OODT_BASE"/tomcat/bin/"$TOMCAT_EXEC" stop "$@" >> "$OODT_OUT" 2>&1 &
+  if [ -x "$SOLR_SERVER_HOME"/bin/"$SOLR_EXEC" ]; then
+    "$SOLR_SERVER_HOME"/bin/"$SOLR_EXEC" stop -p "$SOLR_PORT" >> "$OODT_OUT" 2>&1 &
+  fi
   popd
 else
   echo "Usage: oodt.sh ( commands ... )"


### PR DESCRIPTION
Second of the three steps in #215, **stacked on #216**. The war is still what serves Solr here; this puts the standalone server in the distribution and gives it a lifecycle, so the switch in step three is only a change of URLs.

### Why it can't be fetched like Tomcat

Tomcat comes from Maven Central as `org.apache.tomcat:tomcat:zip` via `dependency:unpack`. **Solr stopped publishing a distribution artifact when it stopped being a war**, and it is not on Central at all. So `maven-antrun-plugin` downloads it from `archive.apache.org` during `prepare-package` and unpacks it. `skipexisting` means a rebuild does not pull 343 MB again.

### Two directories, deliberately apart

| | |
|---|---|
| `solr-server/` | the engine — `bin/solr`, `server/`, its own Jetty |
| `solr/` | the Solr home — DRAT's cores, their configuration and data |

Replacing the engine on a future upgrade is then a swap of one directory and a version property, and none of DRAT's own data moves with it.

### Lifecycle

`bin/oodt` starts and stops Solr alongside Tomcat. `--solr-home` points it at `solr/`; `--user-managed` keeps it out of SolrCloud, which DRAT does not use. `SOLR_PORT` overrides the 8983 default. Both calls are guarded on `bin/solr` being present, so a distribution without it still starts.

### Verified on a clean unpack

- the tarball carries `solr-server/`, and `bin/solr` is `0755` **in the archive** (not just on disk)
- `bin/oodt start` brings Solr up on 8983 with both cores loaded and **no init failures**, alongside Tomcat and the three services
- `bin/oodt stop` takes it down again

The tarball goes from 1633 MB to 1976 MB. That is the cost of the engine being in the box rather than an install step — which is the trade we picked deliberately, to keep this a clean install.