### PR TITLE
Route the Proteus charts to Solr through proteus-services

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ jdk:
 #  - openjdk11
 
 env:
-  - FILEMGR_URL=http://localhost:9000 WORKFLOW_URL=http://localhost:9001 RESMGR_URL=http://localhost:9002 SOLR_DRAT_URL=http://localhost:8080/solr/drat
+  - FILEMGR_URL=http://localhost:9000 WORKFLOW_URL=http://localhost:9001 RESMGR_URL=http://localhost:9002 SOLR_DRAT_URL=http://localhost:8983/solr/drat
 
 before_install:
   - export M2_HOME=/usr/local/maven

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ENV PGE_ROOT=$DRAT_HOME/pge
 ENV PCS_HOME=$DRAT_HOME/pcs
 ENV FMPROD_HOME=$DRAT_HOME/tomcat/webapps/fmprod/WEB-INF/classes/
 ENV PATH=$JAVA_HOME/bin:$PATH
-ENV SOLR_DRAT_URL=http://localhost:8080/solr/drat
+ENV SOLR_DRAT_URL=http://localhost:8983/solr/drat
 ENV DRAT_EXCLUDE=""
 
 RUN apt-get update && apt-get install -y --no-install-recommends python3 python3-pip && pip3 install requests && mkdir -p /root/drat/deploy && tar xvfz dms-distribution-1.1-SNAPSHOT-bin.tar.gz -C /root/drat/deploy/ \

--- a/distribution/src/main/resources/bin/drat
+++ b/distribution/src/main/resources/bin/drat
@@ -38,11 +38,18 @@ function print_help {
 }
 
 function print_ui_info {
-    echo "Navigate to http://${OODT_HOST}:8080/opsui/ to view the OODT browser and http://${OODT_HOST}:8080/solr to view the Solr catalog."
+    echo "Navigate to http://${OODT_HOST}:8080/opsui/ to view the OODT browser and http://${OODT_HOST}:8983/solr to view the Solr catalog."
 }
 
 FILEMGR_URL=http://${OODT_HOST}:9000
-SOLR_URL=http://${OODT_HOST}:8080/solr/drat
+SOLR_URL=http://${OODT_HOST}:8983/solr/drat
+
+# Prefer the JDK DRAT is configured with over whatever happens to be on PATH.
+if [ -n "$JAVA_HOME" ] && [ -x "$JAVA_HOME/bin/java" ]; then
+    RUNJAVA="$JAVA_HOME/bin/java"
+else
+    RUNJAVA=java
+fi
 CLIENT_URL=http://${OODT_HOST}:9001
 OPSUI_URL=http://${OODT_HOST}:8080/opsui
 
@@ -79,7 +86,12 @@ function index {
     check_services_running
     check_num_args "index" $# 1
     pushd $DRAT_HOME/filemgr/bin >> $DRAT_HOME/logs/drat.log 2>&1
-    java -DSOLR_INDEXER_CONFIG=../etc/indexer.properties -cp "../lib/*" \
+    # Bare "java" takes whatever is first on PATH, which is often an older
+    # JDK than the one DRAT is configured for. SolrJ 10 is compiled for Java
+    # 17, so this step failed with UnsupportedClassVersionError on a machine
+    # whose default java was 11, while the services themselves ran fine on
+    # JAVA_HOME.
+    "$RUNJAVA" -DSOLR_INDEXER_CONFIG=../etc/indexer.properties -cp "../lib/*" \
     org.apache.oodt.cas.filemgr.tools.SolrIndexer --all --fmUrl $FILEMGR_URL --optimize --solrUrl $SOLR_URL $1
     popd >> $DRAT_HOME/logs/drat.log 2>&1
 }
@@ -171,7 +183,7 @@ function check_services_running {
 
 function solr_delete_all {
     local core=$1
-    curl -sf -H 'Content-Type: text/xml' "http://${OODT_HOST}:8080/solr/${core}/update?commit=true" \
+    curl -sf -H 'Content-Type: text/xml' "http://${OODT_HOST}:8983/solr/${core}/update?commit=true" \
         --data-binary '<delete><query>*:*</query></delete>' > /dev/null
 }
 
@@ -180,7 +192,11 @@ function solr_delete_all {
 function reset_running {
     check_services_running
     echo "Resetting live DRAT state"
-    curl -sf -X POST "http://${OODT_HOST}:8080/proteus/drat/reset" > /dev/null
+    # /proteus is the Vue application now; the services moved to
+    # /proteus-services when the modules were renamed. This called the old
+    # path, and -sf meant the 404 was swallowed, so reset silently did
+    # nothing and drat go carried on against stale state.
+    curl -sf -X POST "http://${OODT_HOST}:8080/proteus-services/drat/reset" > /dev/null
     solr_delete_all drat
     rm -rf "$DRAT_HOME/data/archive/"*
     rm -rf "$DRAT_HOME/data/jobs/"*

--- a/webapps/proteus-services/src/main/java/drat/proteus/rest/SolrQueryResource.java
+++ b/webapps/proteus-services/src/main/java/drat/proteus/rest/SolrQueryResource.java
@@ -1,0 +1,129 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package drat.proteus.rest;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.UriInfo;
+
+import drat.proteus.services.constants.ProteusEndpointConstants;
+
+/**
+ * Read-only passthrough to Solr for the browser.
+ *
+ * The Proteus charts query Solr directly. That worked while Solr was a war
+ * inside the same Tomcat the interface is served from, because the request was
+ * same-origin. Solr now runs as its own application on its own port, so those
+ * requests became cross-origin and the browser blocks them.
+ *
+ * Rather than enable CORS on Solr -- which would mean editing the bundled
+ * Jetty inside solr-server/, the directory meant to be replaced wholesale on
+ * the next upgrade -- the charts come through here instead, and stay
+ * same-origin.
+ *
+ * Only select is exposed, and only over GET. The browser has no business
+ * reaching /update, and this deliberately gives it no way to.
+ */
+@Path("/solr")
+@Produces(MediaType.APPLICATION_JSON)
+public class SolrQueryResource {
+
+  private static final Logger LOG = Logger.getLogger(SolrQueryResource.class.getName());
+
+  /** The cores DRAT actually has. An unknown name is not forwarded. */
+  private static final List<String> CORES = java.util.Arrays.asList("drat", "statistics");
+
+  @GET
+  @Path("/{core}/select")
+  public String select(@PathParam("core") String core, @Context UriInfo uriInfo) {
+    if (!CORES.contains(core)) {
+      LOG.warning("Refusing to proxy a query for unknown core: [" + core + "]");
+      return "{\"error\":\"unknown core\"}";
+    }
+
+    StringBuilder url = new StringBuilder(ProteusEndpointConstants.SOLR_BASE_URL);
+    url.append("/solr/").append(core).append("/select");
+
+    String separator = "?";
+    MultivaluedMap<String, String> params = uriInfo.getQueryParameters();
+    for (Map.Entry<String, List<String>> param : params.entrySet()) {
+      for (String value : param.getValue()) {
+        url.append(separator);
+        url.append(encode(param.getKey())).append('=').append(encode(value));
+        separator = "&";
+      }
+    }
+
+    return read(url.toString());
+  }
+
+  private static String encode(String value) {
+    try {
+      return URLEncoder.encode(value, "UTF-8");
+    } catch (Exception e) {
+      return value;
+    }
+  }
+
+  private String read(String target) {
+    HttpURLConnection connection = null;
+    try {
+      connection = (HttpURLConnection) new URL(target).openConnection();
+      connection.setConnectTimeout(2000);
+      connection.setReadTimeout(30000);
+      InputStream stream = connection.getResponseCode() < 400
+          ? connection.getInputStream() : connection.getErrorStream();
+      if (stream == null) {
+        return "{\"error\":\"Solr returned HTTP " + connection.getResponseCode() + "\"}";
+      }
+      try {
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        byte[] bytes = new byte[4096];
+        int count;
+        while ((count = stream.read(bytes)) != -1) {
+          buffer.write(bytes, 0, count);
+        }
+        return new String(buffer.toByteArray(), StandardCharsets.UTF_8);
+      } finally {
+        stream.close();
+      }
+    } catch (Exception e) {
+      LOG.warning("Unable to query Solr at [" + target + "]: " + e.getLocalizedMessage());
+      return "{\"error\":\"Unable to reach Solr\"}";
+    } finally {
+      if (connection != null) {
+        connection.disconnect();
+      }
+    }
+  }
+}

--- a/webapps/proteus-services/src/main/webapp/WEB-INF/web.xml
+++ b/webapps/proteus-services/src/main/webapp/WEB-INF/web.xml
@@ -33,7 +33,7 @@
     <servlet-class>org.apache.cxf.jaxrs.servlet.CXFNonSpringJaxrsServlet</servlet-class>
     <init-param>
       <param-name>jaxrs.serviceClasses</param-name>
-      <param-value>drat.proteus.rest.DratRestResource,drat.proteus.rest.ServicesRestResource,drat.proteus.workflow.rest.WorkflowRestResource,drat.proteus.filemgr.rest.FileManagerRestResource</param-value>
+      <param-value>drat.proteus.rest.DratRestResource,drat.proteus.rest.ServicesRestResource,drat.proteus.workflow.rest.WorkflowRestResource,drat.proteus.filemgr.rest.FileManagerRestResource,drat.proteus.rest.SolrQueryResource</param-value>
     </init-param>
     <init-param>
       <param-name>jaxrs.providers</param-name>

--- a/webapps/proteus/src/main/webapp/resources/src/components/auditsummarycomp.vue
+++ b/webapps/proteus/src/main/webapp/resources/src/components/auditsummarycomp.vue
@@ -55,11 +55,11 @@ the License.
 
             var rowCount = 0;
 
-          axios.get(this.origin + '/solr/statistics/select?q=type:software&fl=license_*,id&sort=id+asc&wt=json')
+          axios.get(this.origin + '/proteus-services/solr/statistics/select?q=type:software&fl=license_*,id&sort=id+asc&wt=json')
           .then(response2=>{
               rowCount = response2.data.response.numFound;
                if(response2.data.response.numFound!=null){
-                axios.get(this.origin + '/solr/statistics/select?q=type:software&rows='+rowCount+'&fl=license_*,id&sort=id+asc&wt=json')
+                axios.get(this.origin + '/proteus-services/solr/statistics/select?q=type:software&rows='+rowCount+'&fl=license_*,id&sort=id+asc&wt=json')
                 .then(response=>{
               
 

--- a/webapps/proteus/src/main/webapp/resources/src/components/barchartcomp.vue
+++ b/webapps/proteus/src/main/webapp/resources/src/components/barchartcomp.vue
@@ -63,7 +63,7 @@ import store from './../store/store'
         loadData(){
           if(this.currentRepo=='')return;
           var query = 'parent:"' + this.currentRepo + '" AND type:file';
-          axios.get(this.origin + '/solr/statistics/select?q=' + encodeURIComponent(query) + '&rows=0&facet=true&facet.field=license&wt=json')
+          axios.get(this.origin + '/proteus-services/solr/statistics/select?q=' + encodeURIComponent(query) + '&rows=0&facet=true&facet.field=license&wt=json')
             .then(response=>{
               if(response.data.response.numFound>0){
                 this.licenseTypes=this.buildLicenseFacetBreakdown(response.data);
@@ -80,7 +80,7 @@ import store from './../store/store'
         },
         loadAggregateData(){
           var query = 'id:"' + this.currentRepo + '"';
-          axios.get(this.origin + '/solr/statistics/select?q=' + encodeURIComponent(query) + '&rows=1&fl=license_*&wt=json')
+          axios.get(this.origin + '/proteus-services/solr/statistics/select?q=' + encodeURIComponent(query) + '&rows=1&fl=license_*&wt=json')
             .then(response=>{
               var docs = response.data.response.docs;
               if(docs.length==0){

--- a/webapps/proteus/src/main/webapp/resources/src/components/bublechartcomp.vue
+++ b/webapps/proteus/src/main/webapp/resources/src/components/bublechartcomp.vue
@@ -72,10 +72,10 @@ the License.
             .attr("class", "bubble");
 
 
-        axios.get(this.origin + '/solr/statistics/select?q=type:software&fl=mime_*&wt=json')
+        axios.get(this.origin + '/proteus-services/solr/statistics/select?q=type:software&fl=mime_*&wt=json')
         .then(response2=>{
           if(response2.data.response.numFound!=null){
-              axios.get(this.origin + '/solr/statistics/select?q=type:software&rows='+response2.data.response.numFound+'&fl=mime_*&wt=json')
+              axios.get(this.origin + '/proteus-services/solr/statistics/select?q=type:software&rows='+response2.data.response.numFound+'&fl=mime_*&wt=json')
             .then(response=>{
 
 

--- a/webapps/proteus/src/main/webapp/resources/src/components/licensepiecomp.vue
+++ b/webapps/proteus/src/main/webapp/resources/src/components/licensepiecomp.vue
@@ -47,10 +47,10 @@ the License.
     },
     methods: {
       init(){
-        axios.get(this.origin + '/solr/statistics/select?q=type:software&fl=license_*&wt=json')
+        axios.get(this.origin + '/proteus-services/solr/statistics/select?q=type:software&fl=license_*&wt=json')
         .then(response2=>{
           if(response2.data.response.numFound!=null){
-              axios.get(this.origin + '/solr/statistics/select?q=type:software&rows='+response2.data.response.numFound+'&fl=license_*&wt=json')
+              axios.get(this.origin + '/proteus-services/solr/statistics/select?q=type:software&rows='+response2.data.response.numFound+'&fl=license_*&wt=json')
               .then(function(response) {
 
                 console.log(response.data);

--- a/webapps/proteus/src/main/webapp/resources/src/components/piechart.vue
+++ b/webapps/proteus/src/main/webapp/resources/src/components/piechart.vue
@@ -115,7 +115,7 @@ import store from './../store/store';
         
       },
       loadData(){
-        axios.get(this.origin+"/solr/drat/select?q=producttype:GenericFile&rows=0&facet=true&facet.field=mimetype&wt=json")
+        axios.get(this.origin+"/proteus-services/solr/drat/select?q=producttype:GenericFile&rows=0&facet=true&facet.field=mimetype&wt=json")
             .then(response=>{
               this.data=this.buildMimeBreakdown(response.data, 5);
               this.init();

--- a/webapps/proteus/src/main/webapp/resources/src/components/projectstable.vue
+++ b/webapps/proteus/src/main/webapp/resources/src/components/projectstable.vue
@@ -326,14 +326,14 @@ import store from './../store/store';
         });
       },
       loadData(){
-          axios.get(this.origin+"/solr/statistics/select?q=type:project&wt=json")
+          axios.get(this.origin+"/proteus-services/solr/statistics/select?q=type:project&wt=json")
             .then(response=>{
               this.$log.info(response.data);
               this.docs=response.data.response.docs;
               this.count.numFound = response.data.response.numFound;
               this.count.start = response.data.response.start;
               if(response.data.response.numFound != null && response.data.response.numFound>10){
-                axios.get(this.origin+"/solr/statistics/select?q=type:project&rows="+this.count.numFound+"&wt=json")
+                axios.get(this.origin+"/proteus-services/solr/statistics/select?q=type:project&rows="+this.count.numFound+"&wt=json")
                   .then(response=>{
                     this.docs= response.data.response.docs;
                     this.count.numFound = response.data.response.numFound;
@@ -351,10 +351,10 @@ import store from './../store/store';
             })
       },
       loadLicenseData(){
-        axios.get(this.origin+"/solr/statistics/select?q=id:\""+this.selectedItem.repo+"\"&fl=license_*&wt=json")
+        axios.get(this.origin+"/proteus-services/solr/statistics/select?q=id:\""+this.selectedItem.repo+"\"&fl=license_*&wt=json")
           .then(response2=>{
             if(response2.data.response.numFound!=null){
-                axios.get(this.origin+"/solr/statistics/select?q=id:\""+this.selectedItem.repo+"\"&fl=license_*&rows="+response2.data.response.numFound+"&wt=json")
+                axios.get(this.origin+"/proteus-services/solr/statistics/select?q=id:\""+this.selectedItem.repo+"\"&fl=license_*&rows="+response2.data.response.numFound+"&wt=json")
                 .then(response=>{
                     this.$log.info(response.data);
                     this.license.docs=response.data.response.docs[0];
@@ -365,9 +365,9 @@ import store from './../store/store';
           })
        },
       loadFileDetails(){
-        axios.get(this.origin+"/solr/statistics/select?q=parent:\""+this.selectedItem.repo+"\"&rows=5000&wt=json")
+        axios.get(this.origin+"/proteus-services/solr/statistics/select?q=parent:\""+this.selectedItem.repo+"\"&rows=5000&wt=json")
         .then(response2=>{
-            axios.get(this.origin+"/solr/statistics/select?q=parent:\""+this.selectedItem.repo+"\"&rows="+response2.data.response.numFound+"&wt=json")
+            axios.get(this.origin+"/proteus-services/solr/statistics/select?q=parent:\""+this.selectedItem.repo+"\"&rows="+response2.data.response.numFound+"&wt=json")
             .then(response=>{
               this.sortedfiles  = response.data.response.docs;
             });

--- a/webapps/proteus/src/main/webapp/resources/src/components/statisticscomp.vue
+++ b/webapps/proteus/src/main/webapp/resources/src/components/statisticscomp.vue
@@ -135,7 +135,7 @@ the License.
         });
       },
       loadIndexedFiles(){
-        axios.get(this.origin+"/solr/drat/select?q=producttype:GenericFile&fl=numFound&wt=json&indent=true")
+        axios.get(this.origin+"/proteus-services/solr/drat/select?q=producttype:GenericFile&fl=numFound&wt=json&indent=true")
         .then(response=>{
           this.stat.indexedfiles = response.data.response.numFound;
         });

--- a/webapps/proteus/src/main/webapp/resources/src/components/topmimepiecomp.vue
+++ b/webapps/proteus/src/main/webapp/resources/src/components/topmimepiecomp.vue
@@ -65,10 +65,10 @@ the License.
     },
     methods: {
         init(rows){
-          axios.get(this.origin + '/solr/statistics/select?q=type:software&fl=mime_*&wt=json')
+          axios.get(this.origin + '/proteus-services/solr/statistics/select?q=type:software&fl=mime_*&wt=json')
           .then(response2=>{
             if(response2.data.response.numFound!=null){
-                axios.get(this.origin + '/solr/statistics/select?q=type:software&rows='+response2.data.response.numFound+'&fl=mime_*&wt=json')
+                axios.get(this.origin + '/proteus-services/solr/statistics/select?q=type:software&rows='+response2.data.response.numFound+'&fl=mime_*&wt=json')
                 .then(function(response) {
 
                 console.log(response.data);


### PR DESCRIPTION
**The Solr-backed charts in Proteus have been broken since #218 merged, and that is my fault.**

They query Solr straight from the browser:

```js
axios.get(this.origin + '/solr/statistics/select?q=type:software&fl=mime_*&wt=json')
axios.get(this.origin + '/solr/drat/select?q=producttype:GenericFile&facet=true&facet.field=mimetype')
```

`origin` is `location.origin`, so those went to `:8080/solr` — fine while Solr was a war in the same Tomcat the interface is served from. #218 moved Solr to its own application on 8983, and `:8080/solr` now returns **404**.

When I switched the API paths in #218 I grepped for `/proteus/` and never grepped for `/solr/`. **18 call sites across 8 components**: `piechart`, `bublechartcomp`, `topmimepiecomp`, `projectstable`, `licensepiecomp`, `statisticscomp`, `auditsummarycomp`, `barchartcomp`.

### Why not just point them at 8983

That makes them cross-origin — page on 8080, Solr on 8983 — so the browser blocks them. Enabling CORS on Solr means editing the bundled Jetty inside `solr-server/`, which is precisely the directory meant to be replaced wholesale on the next Solr upgrade, so it would have to be redone every time.

### What this does instead

They go through `proteus-services` and stay same-origin. `SolrQueryResource` forwards the query string to the Solr the services already talk to, and the call sites move from `/solr/` to `/proteus-services/solr/`.

**Only `select`, only over GET.** The browser has no business reaching `/update` and this gives it no way to:

| | |
|---|---|
| `POST /proteus-services/solr/drat/update` | **404** |
| `GET /proteus-services/solr/drat/update` | **404** |
| core name other than `drat`/`statistics` | refused, not forwarded |
| document count after a write attempt | unchanged |

### Verified against a running stack

With the real queries the components make, not just a reachability check:

```
auditsummarycomp:  fl=license_*,id&sort=id+asc
  -> {'license_UNKNOWN': 2, 'license_AL': 5, 'id': '/repo/one'}
     {'license_AL': 3, 'id': '/repo/two'}

piechart:  facet=true&facet.field=mimetype
  -> ['text/x-java-source', 2, 'text/markdown', 1]
```

Dynamic-field globs, sorting and faceting all pass through. The rebuilt bundle carries 18 `/proteus-services/solr/` calls and zero bare `/solr/` ones.

BigTranslate does not have this problem — nothing in its webapps queries Solr from the browser. I checked.