### PR TITLE
Repair the DRAT statistics pipeline end to end

### DIFF
--- a/crawler/src/main/resources/bin/dump_repo_details.py
+++ b/crawler/src/main/resources/bin/dump_repo_details.py
@@ -33,7 +33,7 @@ def main(argv=None):
 		data = ''
 		for line in repoFile:
 			data+=line.strip().decode('utf-8')
-	rep = eval(data)
+	rep = json.loads(data)
 
 	reponame = os.path.basename(os.path.normpath(argv[0]))
 	rep["id"] = "id:"+os.path.normpath(argv[0])

--- a/distribution/src/main/resources/bin/dratstats.py
+++ b/distribution/src/main/resources/bin/dratstats.py
@@ -27,8 +27,8 @@ import time
 import shutil
 import datetime
 from urllib.request import urlopen, Request
+from urllib.parse import quote
 import json
-import xmlrpc
 
 # Check for environment variables
 def check_env_var():
@@ -41,8 +41,8 @@ def check_env_var():
 	if os.getenv("SOLR_DRAT_URL") == None:
 		print("Environment variable $SOLR_DRAT_URL is not set.")
 		sys.exit(1)
-	if os.getenv("WORKFLOW_URL") == None:
-		print("Environment variable $WORKFLOW_URL is not set.")
+	if os.getenv("PROTEUS_URL") == None:
+		print("Environment variable $PROTEUS_URL is not set.")
 		sys.exit(1)
 
 
@@ -74,7 +74,7 @@ def count_num_files(path, exclude):
 
 # Prints usage of this script
 def help():
-	print >>sys.stderr, "\n\nUsage: python dratstats.py <path to list of repository URLs> <path to output directory>\n"
+	print("\n\nUsage: python dratstats.py <path to list of repository URLs> <path to output directory>\n", file=sys.stderr)
 
 
 # Printing out on Console
@@ -120,13 +120,13 @@ def oodt_process(command):
 	try:
 		retcode = subprocess.call("${DRAT_HOME}/bin/oodt" + " " + command, shell=True)
 		if retcode < 0:
-			print >>sys.stderr, "ODDT process was terminated by signal", -retcode, ". OODT failed to " + command + ". Aborting..."
+			print("ODDT process was terminated by signal", -retcode, ". OODT failed to " + command + ". Aborting...", file=sys.stderr)
 			sys.exit(1)
 		elif retcode > 0:
-			print >>sys.stderr, "OODT process returned", retcode, ". OODT failed to " + command + ". Aborting..."
+			print("OODT process returned", retcode, ". OODT failed to " + command + ". Aborting...", file=sys.stderr)
 			sys.exit(1)
 	except OSError as e:
-		print >>sys.stderr, "OODT execution failed:", e, ". OODT failed to " + command + ". Aborting..."
+		print("OODT execution failed:", e, ". OODT failed to " + command + ". Aborting...", file=sys.stderr)
 		sys.exit(1)
 
 
@@ -142,13 +142,13 @@ def drat_process(command, repository):
 		elif command == "map" or command == "reduce":
 			retcode = subprocess.call("${DRAT_HOME}/bin/drat" + " " + command + " &", shell=True)
 		if retcode < 0:
-			print >>sys.stderr, "DRAT " + command + " process was terminated by signal", -retcode, ". Aborting..."
+			print("DRAT " + command + " process was terminated by signal", -retcode, ". Aborting...", file=sys.stderr)
 			retval = False
 		elif retcode > 0:
-			print >>sys.stderr, "DRAT " + command + " process returned", retcode, ". Aborting..."
+			print("DRAT " + command + " process returned", retcode, ". Aborting...", file=sys.stderr)
 			retval = False
 	except OSError as e:
-		print >>sys.stderr, "DRAT " + command + " execution failed:", e, ". Aborting..."
+		print("DRAT " + command + " execution failed:", e, ". Aborting...", file=sys.stderr)
 		retval = False
 	return retval
 
@@ -169,23 +169,33 @@ def drat_reset():
 	os.mkdir(os.getenv("DRAT_HOME") + "/data/jobs")
 
 
+# Ask the workflow manager which instances are currently in a given state.
+#
+# This used to be an xmlrpc.client.ServerProxy call straight at
+# $WORKFLOW_URL. mnemosyne#95 removed XML-RPC from the workflow manager,
+# so the call can no longer connect at all. The same question now goes
+# over HTTP to proteus-services, which holds an Avro client.
+def workflow_instances_by_status(status):
+	url = os.getenv("PROTEUS_URL").rstrip("/") + "/workflowservice/instances/" + quote(status)
+	try:
+		response = urlopen(url, timeout=30)
+		return json.loads(response.read().decode("utf-8"))
+	except Exception as e:
+		print("Unable to reach the workflow service at " + url + ": " + str(e))
+		return []
+
+
 # Check if there are any pending PGE jobs in the queue
 def job_in_queue(job_name):
 	status = "PGE EXEC"
-	server = xmlrpc.client.ServerProxy(os.getenv("WORKFLOW_URL"), verbose=False)
-	
 
 	for x in range(0,6):
-		response = server.workflowmgr.getWorkflowInstancesByStatus(status)
-
-		for i in range(0, len(response)):
-		#print response[i]["sharedContext"]["TaskId"]
-			if response[i]["sharedContext"]["TaskId"][0] == job_name:
+		for instance in workflow_instances_by_status(status):
+			task_ids = instance.get("taskIds") or []
+			if task_ids and task_ids[0] == job_name:
 				return True
 
-		time.sleep(3)		
-
-	
+		time.sleep(3)
 
 	return False
 
@@ -306,25 +316,25 @@ def run(repos_list, output_dir):
 						wait_for_job("urn:drat:RatAggregator")
 						time.sleep(10)
 						retval = drat_process("reduce",None)
-                                                print ("\nwaiting for Rat Aggregator...\n")
-                                                wait_for_job("urn:drat:RatAggregator")
+						print ("\nwaiting for Rat Aggregator...\n")
+						wait_for_job("urn:drat:RatAggregator")
 			
 
 			time.sleep(5)
 
-                        if(retval):
-                                # Copy Data with datetime variables above, extract output from RatAggregate file, extract data from Solr Core
-                                printnow ("\nCopying data to Solr and Output Directory...\n")
+			if(retval):
+				# Copy Data with datetime variables above, extract output from RatAggregate file, extract data from Solr Core
+				printnow ("\nCopying data to Solr and Output Directory...\n")
 
-                                # Copying data to Output Directory
-                                repos_out = output_dir + "/" + normalize_path(rep["repo"])
-                                shutil.copytree(os.getenv("DRAT_HOME") + "/data/archive", repos_out + "/data/archive")
-                                shutil.copytree(os.getenv("DRAT_HOME") + "/data/jobs", repos_out + "/data/jobs")
-                                shutil.copytree(os.getenv("DRAT_HOME") + "/data/workflow", repos_out + "/data/workflow")
-                                print("\nData copied to Solr and Output Directory: OK\n")
+				# Copying data to Output Directory
+				repos_out = output_dir + "/" + normalize_path(rep["repo"])
+				shutil.copytree(os.getenv("DRAT_HOME") + "/data/archive", repos_out + "/data/archive")
+				shutil.copytree(os.getenv("DRAT_HOME") + "/data/jobs", repos_out + "/data/jobs")
+				shutil.copytree(os.getenv("DRAT_HOME") + "/data/workflow", repos_out + "/data/workflow")
+				print("\nData copied to Solr and Output Directory: OK\n")
 
 
-                        time.sleep(5)
+			time.sleep(5)
 			print ("\nStopping OODT...\n")
 			oodt_process("stop")
 			time.sleep(20)
@@ -341,7 +351,7 @@ def run(repos_list, output_dir):
 # This is where it all begins
 def main():
 	if len(sys.argv) < 2 or len(sys.argv) > 3:
-		print >>sys.stderr, "\nIncorrect number of arguments passed. Aborting..."
+		print("\nIncorrect number of arguments passed. Aborting...", file=sys.stderr)
 		help()
 		sys.exit(1)
 	
@@ -349,18 +359,18 @@ def main():
 	output_dir = sys.argv[2]
 
 	if not os.path.isfile(repos_list):
-		print >>sys.stderr, "\nRepository list doesn't exists at the path: ", repos_list
+		print("\nRepository list doesn't exists at the path: ", repos_list, file=sys.stderr)
 		help()
 		sys.exit(1)
 
 	if not os.path.isdir(output_dir):
-		print >>sys.stderr, "\nOutput Directory doesn't exist at the path: ", output_dir
+		print("\nOutput Directory doesn't exist at the path: ", output_dir, file=sys.stderr)
 		help()
 		sys.exit(1)
 	
 	dratData = os.getenv("DRAT_HOME") + "/data"
 	if os.path.realpath(output_dir).startswith(dratData):
-		print >>sys.stderr, "\nOutput dir cannot be a sub directory of "+dratData
+		print("\nOutput dir cannot be a sub directory of "+dratData, file=sys.stderr)
 		help()
 		sys.exit(1)
 

--- a/distribution/src/main/resources/bin/gen-apache-clones.py
+++ b/distribution/src/main/resources/bin/gen-apache-clones.py
@@ -25,14 +25,17 @@ with open(os.getenv("DRAT_HOME")+"/conf/apache-repo-list.txt") as ar:
         repoName = repo.split(".")[0].rstrip()
 
         workDir = os.getenv("DRAT_HOME")+"/data/clones/"
-        print "Cloning: ["+repoUrl+"] to ["+workDir+repoName+"]: working dir: ["+workDir+"]"
+        # Popen fails outright if cwd does not exist, and nothing else
+        # creates the clone directory on a fresh deployment.
+        os.makedirs(workDir, exist_ok=True)
+        print("Cloning: ["+repoUrl+"] to ["+workDir+repoName+"]: working dir: ["+workDir+"]")
         cloneCmd = "git clone --depth=1 "+repoUrl
-        print cloneCmd
+        print(cloneCmd)
         args = shlex.split(cloneCmd)
         p = Popen(args, cwd=workDir)
         p.communicate()
         rmCmd = "rm -rf "+repoName+"/.git"
-        print rmCmd
+        print(rmCmd)
         args = shlex.split(rmCmd)
         p2 = Popen(args, cwd=workDir)
         p2.communicate()

--- a/distribution/src/main/resources/bin/gen-apache-repo.py
+++ b/distribution/src/main/resources/bin/gen-apache-repo.py
@@ -23,4 +23,4 @@ with open(os.getenv("DRAT_HOME")+"/conf/apache-repo-list.txt") as ar:
         repoPath = os.getenv("DRAT_HOME")+"/data/clones/"+repoBase
         repoUrl = "http://github.com/apache/"+repo.rstrip()
         repoDesc = repoName
-        print repoPath+" "+repoName+" "+repoUrl+" "+repoDesc
+        print(repoPath+" "+repoName+" "+repoUrl+" "+repoDesc)

--- a/distribution/src/main/resources/bin/setenv.sh
+++ b/distribution/src/main/resources/bin/setenv.sh
@@ -19,6 +19,7 @@ export FILEMGR_HOME=$DRAT_HOME/filemgr
 export PGE_HOME=$DRAT_HOME/pge
 export PCS_HOME=$DRAT_HOME/pcs
 export OPSUI_URL=http://localhost:8080/opsui
+export PROTEUS_URL=http://localhost:8080/proteus-services
 export SOLR_URL=http://localhost:8983/solr
 export FMPROD_HOME=$DRAT_HOME/tomcat/webapps/fmprod/WEB-INF/classes/
 export SOLR_DRAT_URL=http://localhost:8983/solr/drat

--- a/pge/src/main/resources/bin/mime_partitioner/mime_rat_partitioner.py
+++ b/pge/src/main/resources/bin/mime_partitioner/mime_rat_partitioner.py
@@ -44,7 +44,7 @@ def get_current_repo():
     repo_file_url = os.path.join(get_drat_home(), "data", "repo")
     try:
         with open(repo_file_url, 'r') as repo_file:
-            repo = eval(repo_file.read())
+            repo = json.loads(repo_file.read())
             return os.path.realpath(repo["repo"])
     except Exception:
         return None
@@ -76,8 +76,11 @@ def executeRatJobs(url, num, type, workflowUrl, taskIds, current_repo):
     # build filepath list
     # send filepath and name list to CAS-PGE RAT job
     # first get numRecords
-    if not url.endswith("/"):
-        url = url + "/"
+    # This appended a trailing slash to a base that is then concatenated with
+    # solrPostfix, which already starts with one, so every request went to
+    # /solr/drat//select/. Older Solr collapsed the empty path segment; Solr 10
+    # answers 400, which aborted RAT execution for every MIME type in turn.
+    url = url.rstrip("/")
     solrUrl = url+solrPostfix.replace("$type", type)
     print("GET "+solrUrl)
     numFound = 0
@@ -116,10 +119,14 @@ def executeRatJobs(url, num, type, workflowUrl, taskIds, current_repo):
             execute_dynamic_workflow(workflowUrl, taskIds, metadata)
         
 
+# Solr's wt=python response writer emitted Python literals, which is why
+# these responses were parsed with eval(). Solr 10 no longer has that
+# writer and silently answers wt=python with JSON, whose true/false/null
+# are not Python names -- eval() then dies with NameError. Parse the JSON.
 def get_mime_types(solrUrl):
     neg_mimetype = ["image", "application", "text", "video", "audio", "message", "multipart"]
-    connection = urlopen(solrUrl + "/select?q=*%3A*&rows=0&facet=true&facet.field=mimetype&wt=python&indent=true")
-    response = eval(connection.read())
+    connection = urlopen(solrUrl + "/select?q=*%3A*&rows=0&facet=true&facet.field=mimetype&wt=json&indent=true")
+    response = json.loads(connection.read())
     mime_count = response["facet_counts"]["facet_fields"]["mimetype"]
     stats = {}
     for i in range(0, len(mime_count), 2):

--- a/pge/src/main/resources/bin/rat_aggregator/rat_aggregator.py
+++ b/pge/src/main/resources/bin/rat_aggregator/rat_aggregator.py
@@ -111,7 +111,7 @@ def main(argv=None):
       data = ''
       for line in repoFile:
           data+=line.decode('utf-8')
-   rep = eval(data)
+   rep = json.loads(data)
    current_repo = os.path.realpath(rep["repo"])
    
    index_solr(json.dumps([rep]))
@@ -188,9 +188,9 @@ def main(argv=None):
 
       # Extract data from Solr
       neg_mimetype = ["image", "application", "text", "video", "audio", "message", "multipart"]
-      connection = requests.get(os.getenv("SOLR_URL") + "/drat/select?q=*%3A*&rows=0&facet=true&facet.field=mimetype&wt=python&indent=true")
+      connection = requests.get(os.getenv("SOLR_URL") + "/drat/select?q=*%3A*&rows=0&facet=true&facet.field=mimetype&wt=json&indent=true")
 
-      response = eval(connection.text)
+      response = json.loads(connection.text)
       mime_count = response["facet_counts"]["facet_fields"]["mimetype"]
 
       for i in range(0, len(mime_count), 2):
@@ -202,14 +202,14 @@ def main(argv=None):
       stats["files"] = count_num_files(rep["repo"], ".git")
       # Index RAT logs into Solr
       connection = requests.get(os.getenv("SOLR_URL") +
-                                "/drat/select?q=*%3A*&fl=filename%2Cfilelocation%2Cmimetype&wt=python&rows=0&indent=true")
-      response = eval(connection.text)
+                                "/drat/select?q=*%3A*&fl=filename%2Cfilelocation%2Cmimetype&wt=json&rows=0&indent=true")
+      response = json.loads(connection.text)
       num_found = response['response']['numFound']
       connection = requests.get(os.getenv("SOLR_URL") +
-                                "/drat/select?q=*%3A*&fl=filename%2Cfilelocation%2Cmimetype&wt=python&rows="
+                                "/drat/select?q=*%3A*&fl=filename%2Cfilelocation%2Cmimetype&wt=json&rows="
                                 + str(num_found) +"&indent=true")
 
-      response = eval(connection.text)
+      response = json.loads(connection.text)
       docs = response['response']['docs']
       file_data = []
       unique_file_data = {}

--- a/webapps/proteus-services/src/main/java/drat/proteus/workflow/rest/WorkflowRestResource.java
+++ b/webapps/proteus-services/src/main/java/drat/proteus/workflow/rest/WorkflowRestResource.java
@@ -26,7 +26,17 @@ import javax.ws.rs.DefaultValue;
 import javax.ws.rs.core.MediaType;
 
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Vector;
 import java.util.logging.Logger;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.PathParam;
+
+import org.apache.oodt.cas.workflow.structs.WorkflowInstance;
 
 
 import backend.OodtClientPool;
@@ -45,6 +55,42 @@ public class WorkflowRestResource {
     public WorkflowRestResource() {
     }
     
+    /**
+     * The workflow instances currently in a given state, with the TaskId from
+     * each one's shared context.
+     *
+     * dratstats.py needs exactly this to decide whether a PGE is still running,
+     * and used to get it by calling workflowmgr.getWorkflowInstancesByStatus
+     * over XML-RPC. mnemosyne#95 removed XML-RPC, which left the statistics
+     * step with no way to ask the question at all, so the statistics core was
+     * never populated and every chart on the Proteus dashboard stayed empty.
+     */
+    @GET
+    @Path("/instances/{status}")
+    public List<Map<String, Object>> instancesByStatus(@PathParam("status") String status) {
+        List<Map<String, Object>> out = new ArrayList<Map<String, Object>>();
+        try {
+            Vector instances = OodtClientPool.withWorkflowManagerClient(client ->
+                client.getWorkflowInstancesByStatus(status));
+            if (instances == null) {
+                return out;
+            }
+            for (Object o : instances) {
+                WorkflowInstance instance = (WorkflowInstance) o;
+                Map<String, Object> entry = new HashMap<String, Object>();
+                entry.put("id", instance.getId());
+                entry.put("taskIds", instance.getSharedContext() == null
+                    ? new ArrayList<String>()
+                    : instance.getSharedContext().getAllMetadata("TaskId"));
+                out.add(entry);
+            }
+        } catch (Exception e) {
+            LOG.info("Unable to list workflow instances with status [" + status
+                + "]: " + e.getMessage());
+        }
+        return out;
+    }
+
     @POST
     @Path("/dynamic")
     @Produces(MediaType.TEXT_PLAIN)


### PR DESCRIPTION
The Proteus dashboard rendered blank because the `statistics` core was empty, and it was empty because **every stage that fills it was broken**. These fail independently — fixing any one alone changes nothing.

### 1. `wt=python` is gone in Solr 10 (7 call sites)
Solr's Python response writer emitted Python literals, which is why these responses were parsed with `eval()`. Solr 10 has no such writer and silently answers `wt=python` with JSON, whose `true`/`false` are not Python names:

```
NameError: name 'true' is not defined
```

MimePartitioner died there **before submitting a single audit** — so no RatCodeAudit ever ran, no RAT logs were produced, and everything downstream was zero. Switched to `wt=json` + `json.loads`.

### 2. Double slash → HTTP 400
`executeRatJobs` appended a trailing slash to a base that is concatenated with a postfix already starting with one, so every request went to `/solr/drat//select/`. Older Solr collapsed the empty segment; Solr 10 returns 400 and RAT execution aborted for each MIME type in turn.

### 3. `dratstats.py` did not compile
Twelve lines were indented with spaces in a tab-indented file — `TabError` on import, so the script could not run at all. It also:
- called the workflow manager over **XML-RPC**, removed in mnemosyne#95
- used Python 2 `print >>sys.stderr` in **11 places**, including every OODT/DRAT failure handler, so a failing command raised `TypeError` instead of reporting the error

### 4. New endpoint for the workflow query
`GET /proteus-services/workflowservice/instances/{status}` returns each instance with the `TaskId` from its shared context — exactly what `job_in_queue` needs. proteus-services already holds an Avro client, so nothing new has to speak the workflow protocol.

### 5. `gen-apache-*` never ported to Python 3
Both still used `print` statements; `gen-apache-clones.py` also runs `Popen` with a `cwd` nothing creates.

## Verified end to end on a live stack
- partitioner submits 6 dynamic workflows across 6 MIME types
- RAT audits run and **ingest 6 logs** into `data/archive/rat/*/`
- aggregator reports `Binaries 24, Archives 2, Standards 49, Apache 22, Unknown 27`
- `statistics` core: `type:software` doc carrying those `license_*` and `mime_*` counts, plus `type:project` and 75 `type:file` docs
- dashboard DOM went from **zero chart content** to 11 SVG arcs labelled Apache / Standards / Binaries / octet-stream / x-python